### PR TITLE
CIN-11539: Fix to insert query to be compatible with cinchy v5, blanked out fields after insert/updates

### DIFF
--- a/src/app/core/sidenav/sidenav.component.html
+++ b/src/app/core/sidenav/sidenav.component.html
@@ -25,7 +25,7 @@
 
   <div class="useful-links-wrapper">
     <hr>
-    <p class="link-with-icon" *ngIf="(canInsert && rowId && rowId != 'null')" (click)="createNewForm()">
+    <p class="link-with-icon" *ngIf="(canInsert && rowId && rowId != 'null')" (click)="createNewRecord()">
       <mat-icon>queue</mat-icon>
       <span>Create New Record</span>
     </p>

--- a/src/app/core/sidenav/sidenav.component.ts
+++ b/src/app/core/sidenav/sidenav.component.ts
@@ -20,10 +20,7 @@ export class SidenavComponent implements OnInit, OnDestroy {
   @Input() tableId: string | number;
   @Input() formMetadata: IFormMetadata;
 
-  @Input() set rowId(value: string | number) {
-    this._rowId = value
-    this.filteredTableUrl = this.tableUrl ? `${this.tableUrl}?viewId=0&fil[Cinchy%20Id].Op=Equals&fil[Cinchy%20Id].Val=${value}` : this.filteredTableUrl;
-  };
+  rowId: string | number;
 
   @Input() set tableUrl(value: string) {
     this._tableUrl = value
@@ -31,20 +28,15 @@ export class SidenavComponent implements OnInit, OnDestroy {
   };
 
   @Output() closeSideBar = new EventEmitter<any>();
-  @Output() createNewFormClicked = new EventEmitter<any>();
+
   toggleMenu: boolean;
   canInsert: boolean;
   selectedSection: string;
   filteredTableUrl: string;
   destroy$: Subject<boolean> = new Subject<boolean>();
-  _rowId;
   _tableUrl;
   showNewContactLink: boolean;
   createNewOptionName: string;
-
-  get rowId() {
-    return this._rowId;
-  }
 
   get tableUrl() {
     return this._tableUrl;
@@ -61,6 +53,11 @@ export class SidenavComponent implements OnInit, OnDestroy {
     this.subscribeToSectionClickedFromForm();
     this.subscribeToRenderedSectionUpdates();
     this.createNewOptionName = this.formMetadata.createNewOptionName;
+
+    this.appStateService.onRecordSelected().subscribe(resp => {
+      this.rowId = resp.cinchyId;
+      this.filteredTableUrl = this.tableUrl ? `${this.tableUrl}?viewId=0&fil[Cinchy%20Id].Op=Equals&fil[Cinchy%20Id].Val=${resp}` : this.filteredTableUrl;
+    });
   }
 
   subscribeToRenderedSectionUpdates() {
@@ -90,9 +87,9 @@ export class SidenavComponent implements OnInit, OnDestroy {
     sectionEle?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
-  createNewForm() {
+  createNewRecord() {
     this.sectionClicked(this.formSectionsMetadata[0]);
-    this.createNewFormClicked.emit();
+    this.appStateService.setRecordSelected(null);
   }
 
   openAddNewOptionDialog() {

--- a/src/app/dialogs/add-new-option-dialog/add-new-option-dialog.component.html
+++ b/src/app/dialogs/add-new-option-dialog/add-new-option-dialog.component.html
@@ -1,7 +1,6 @@
 <div class="form-container" *ngIf="formSectionsMetadata">
   <cinchy-dynamic-forms class="full-height-element"
                         [formId]="formId"
-                        [rowId]="null"
                         [formMetadata]="formMetadata"
                         [formSectionsMetadata]="formSectionsMetadata"
                         [lookupRecords]="lookupRecords"

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -90,10 +90,14 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges, OnDestroy
         this.rowId = null;
         this.currentRow = null;
       } else {
+        const setLookupRecords = this.rowId == null;
         this.rowId = resp.cinchyId;
+        if (setLookupRecords)
+          this.setLookupRecords(this.lookupRecordsList);
       }
-      if (resp == null || !(resp.doNotReloadForm))
+      if (resp == null || !(resp.doNotReloadForm)) {
         await this.loadForm();
+      }
     });
   }
 

--- a/src/app/pages/form-wrapper/form-wrapper.component.html
+++ b/src/app/pages/form-wrapper/form-wrapper.component.html
@@ -31,12 +31,10 @@
   <ng-template #sideMainContent>
     <app-sidenav *ngIf="formSectionsMetadata"
                  [formId]="formId"
-                 [rowId]="rowId"
                  [tableId]="formMetadata.tableId"
                  [tableUrl]="formMetadata.tableUrl"
                  [formMetadata]="formMetadata"
-                 (closeSideBar)=sidenav.toggle()
-                 (createNewFormClicked)="setDefaultForm()">
+                 (closeSideBar)=sidenav.toggle()>
     </app-sidenav>
   </ng-template>
 
@@ -44,12 +42,10 @@
     <div class="form-container" *ngIf="formSectionsMetadata && lookupRecords">
       <cinchy-dynamic-forms class="full-height-element"
                             [formId]="formId"
-                            [rowId]="rowId"
                             [formMetadata]="formMetadata"
                             [formSectionsMetadata]="formSectionsMetadata"
                             [lookupRecords]="lookupRecords"
-                            (eventHandler)="onSaved($event)"
-                            (rowUpdated)="rowUpdatedFromForm($event)">
+                            (eventHandler)="onSaved($event)">
       </cinchy-dynamic-forms>
     </div>
   </ng-template>

--- a/src/app/pages/form-wrapper/form-wrapper.component.ts
+++ b/src/app/pages/form-wrapper/form-wrapper.component.ts
@@ -1,9 +1,7 @@
 import { ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
 import { CinchyQueryService } from '../../services/cinchy-query.service';
 import { AppStateService } from '../../services/app-state.service';
-import { ActivatedRoute, Router } from '@angular/router';
-import { DialogService } from '../../services/dialog.service';
-import { CinchyService } from '@cinchy-co/angular-sdk';
+import { ActivatedRoute } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { NgxSpinnerService } from 'ngx-spinner';
 import { MediaMatcher } from '@angular/cdk/layout';
@@ -31,7 +29,6 @@ export class FormWrapperComponent implements OnInit {
   constructor(
     private cinchyQueryService: CinchyQueryService,
     private appStateService: AppStateService,
-    private router: Router,
     private activatedRoute: ActivatedRoute,
     private toastr: ToastrService,
     private spinner: NgxSpinnerService,
@@ -49,7 +46,8 @@ export class FormWrapperComponent implements OnInit {
     let { formId, rowId } = this.activatedRoute.snapshot.queryParams;
     console.log('From session', sessionStorage.getItem('formId'), sessionStorage.getItem('rowId'));
     this.formId = formId || this.appStateService.formId || sessionStorage.getItem('formId');
-    this.rowId = rowId || this.appStateService.rowId || sessionStorage.getItem('rowId');
+
+    this.appStateService.setRecordSelected(this.rowId);
   }
 
   async loadFormMetadata() {
@@ -98,16 +96,7 @@ export class FormWrapperComponent implements OnInit {
     this.toastr.error('Could not fetch the form\'s metadata. You may not have the necessary entitlements to view this form.', 'Error');
   }
 
-  setDefaultForm() {
-    this.rowId = null;
-  }
-
   onSaved(data) {
     this.loadLookupRecords(this.formMetadata);
-    this.rowId = data;
-  }
-
-  rowUpdatedFromForm(rowId) {
-    this.rowId = rowId;
   }
 }

--- a/src/app/pages/form-wrapper/form-wrapper.component.ts
+++ b/src/app/pages/form-wrapper/form-wrapper.component.ts
@@ -46,7 +46,7 @@ export class FormWrapperComponent implements OnInit {
     let { formId, rowId } = this.activatedRoute.snapshot.queryParams;
     console.log('From session', sessionStorage.getItem('formId'), sessionStorage.getItem('rowId'));
     this.formId = formId || this.appStateService.formId || sessionStorage.getItem('formId');
-
+    this.rowId = rowId || this.appStateService.rowId || sessionStorage.getItem('rowId');
     this.appStateService.setRecordSelected(this.rowId);
   }
 

--- a/src/app/pages/healthcheck/healthcheck/healthcheck.component.ts
+++ b/src/app/pages/healthcheck/healthcheck/healthcheck.component.ts
@@ -18,12 +18,12 @@ export class HealthcheckComponent implements OnInit {
   }
 
   getHealthCheckInfo(): void{
-  this._configService.getEnvUrl();
-  this.healthCheck = this._configService.envConfig;
-  delete this.healthCheck.authority;
-  delete this.healthCheck.cinchyRootUrl;
-  delete this.healthCheck.clientId;
-  delete this.healthCheck.redirectUri;   
+    this._configService.loadConfig();
+    this.healthCheck = this._configService.envConfig;
+    delete this.healthCheck.authority;
+    delete this.healthCheck.cinchyRootUrl;
+    delete this.healthCheck.clientId;
+    delete this.healthCheck.redirectUri;   
   }
 
 }

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -14,12 +14,21 @@ export class AppStateService {
   latestRenderedSections$ = new BehaviorSubject<IFormSectionMetadata[]>(null);
   currentSection$ = new BehaviorSubject<string>(null);
   saveClicked$ = new BehaviorSubject<boolean>(null);
+  lastRecordSelect$ = new BehaviorSubject<{ cinchyId: number | string | null, doNotReloadForm: boolean }>(null);
   childRecordUpdated$ = new Subject<boolean>();
   hasFormChanged: boolean;
   savedParentFromChildPlus$ = new Subject<boolean>();
   formMetadata: IFormMetadata;
 
   constructor() { }
+
+  setRecordSelected(cinchyId: number | string | null, doNotReloadForm: boolean = false): void {
+    this.lastRecordSelect$.next({cinchyId, doNotReloadForm});
+  } 
+
+  onRecordSelected(): Observable<{ cinchyId: number | string | null, doNotReloadForm: boolean }> {
+    return this.lastRecordSelect$.asObservable();
+  }
 
   setLatestRenderedSections(sections: IFormSectionMetadata[]){
     this.latestRenderedSections$.next(sections);


### PR DESCRIPTION
- Added a healthcheck call to cinchy web at the beginning to get the versioning Forms is running against
- Change the insert query for new records to use no longer use SELECT @cinchy_row_id if the Cinchy version is v5 due to compatibility issues 
- Fix issues relating to inserts/updates reloading the form twice causing form field values to disappear afterwards