### PR TITLE
CIN-06242: Remove character limit on record lookup

### DIFF
--- a/src/app/pages/form-wrapper/form-wrapper.component.ts
+++ b/src/app/pages/form-wrapper/form-wrapper.component.ts
@@ -84,7 +84,7 @@ export class FormWrapperComponent implements OnInit {
 
   handleOnLookupRecordFilter(filter: string): void {
 
-    let resolvedFilter = (filter ? `LOWER(CAST([${this.formMetadata.subTitleColumn ?? "Cinchy ID"}] as nvarchar)) LIKE LOWER('%${filter}%')` : null);
+    let resolvedFilter = (filter ? `LOWER(CAST([${this.formMetadata.subTitleColumn ?? "Cinchy ID"}] as nvarchar(MAX))) LIKE LOWER('%${filter}%')` : null);
 
     // Ensure that if there is a default filter on the field, it is not lost
     if (resolvedFilter && this.formMetadata.lookupFilter) {

--- a/src/assets/config/config.json
+++ b/src/assets/config/config.json
@@ -1,6 +1,6 @@
 {
-  "authority": "https://cinchy.net/cinchysso",
-  "cinchyRootUrl": "https://cinchy.net",
-  "clientId": "meta-forms-qa",
-  "redirectUri": "https://localhost:3000/"
+  "authority": "<cinchy-domain>/idp",
+  "cinchyRootUrl": "<cinchy-domain>",
+  "clientId": "cinchy_meta_forms",
+  "redirectUri": "<cinchy-domain>/metaforms"
 }

--- a/src/assets/config/config.json
+++ b/src/assets/config/config.json
@@ -1,6 +1,6 @@
 {
-  "authority": "<cinchy-domain>/idp",
-  "cinchyRootUrl": "<cinchy-domain>",
-  "clientId": "cinchy_meta_forms",
-  "redirectUri": "<cinchy-domain>/metaforms"
+  "authority": "https://cinchy.net/cinchysso",
+  "cinchyRootUrl": "https://cinchy.net",
+  "clientId": "meta-forms-qa",
+  "redirectUri": "https://localhost:3000/"
 }


### PR DESCRIPTION
## Problem Description and Current Behaviour

Searching the existing records on a form's record selection appeared to have an arbitrary limit of 30 characters. Inputting any more than 30 characters -- or of any substring which extends beyond the first 30 characters of the label -- causes a failure to match.

## Steps to Reproduce

On a form with labels longer than 30 characters, search for a record in the dropdown in the header with a search term that is either longer than 30 characters or that has characters which overlap with the string outside of the first 30-characters of a particular label that you would like to search for. If you do this character-by-character, you will see the limit in action as the single result will suddenly stop returning once you cross the threshold.

## Desired Behaviour

There should be no limit on the search field

## Investigation

The character limit was actually caused by the filter query using a `CAST` operation on the target label to ensure that the comparison with the search term won't cause a type mismatch. The `CAST` was resolving into an `nvarchar` without  a size explicitly set, and this resulted in an automatic truncation to 30 bytes. This meant that the search term was only running against the first 30 characters of the label.

## Brief description of Solution

The `nvarchar` casting variable was simply given a maximum size allocation, so it will never be truncated beyond the limits imposed by that field in the table itself.