### PR TITLE
CIN-06632: Linked field multi-select behaviour

### DIFF
--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
@@ -92,6 +92,7 @@
       <mat-select class="form-control" multiple #multiSelect
                   *ngIf="!isLoading && !downloadLink"
                   [(ngModel)]="selectedValues" [ngModelOptions]="{standalone: true}"
+                  [compareWith]="compareFn"
                   [disabled]="!canEdit"
                   (selectionChange)="valueChanged()"
                   disableOptionCentering>
@@ -105,26 +106,29 @@
             </ngx-mat-select-search>
           </mat-option>
 
-          <ng-container *ngIf="filteredListMulti | async; let list">
-            <ng-container *ngIf="list.length < maxLimitForMaterialSelect; else cdkOptions">
-              <mat-option class="all-options" *ngFor="let dropdownOption of list"
-                          [value]="dropdownOption"
-                          [title]="dropdownOption.label">
-                {{dropdownOption.displayOnlyLabel ?? dropdownOption.label ?? ""}}
-              </mat-option>
-            </ng-container>
+          <cdk-virtual-scroll-viewport [itemSize]="48" [style.height.px]="4*48" [minBufferPx]="300"
+                                       [maxBufferPx]="600">
+            <mat-option class="all-options" *cdkVirtualFor="let dropdownOption of filteredListMulti | async"
+                        [value]="dropdownOption"
+                        [title]="dropdownOption.label">
+              {{dropdownOption.displayOnlyLabel ?? dropdownOption.label ?? ""}}
+            </mat-option>
 
-            <ng-template #cdkOptions>
-              <cdk-virtual-scroll-viewport [itemSize]="48" [style.height.px]=4*48 [minBufferPx]="300"
-                                           [maxBufferPx]="600">
-                <mat-option class="all-options" *cdkVirtualFor="let dropdownOption of filteredListMulti | async"
-                            [value]="dropdownOption"
-                            [title]="dropdownOption.label">
-                  {{dropdownOption.displayOnlyLabel ?? dropdownOption.label ?? ""}}
-                </mat-option>
-              </cdk-virtual-scroll-viewport>
-            </ng-template>
-          </ng-container>
+            <!--
+              We need to ensure that values which were previously selected still render within the
+              viewport even if they are out of the current view, because otherwise they will be
+              deselected when the value changes. This hack forces them to be present.
+
+              See:
+              See: https://github.com/angular/components/issues/13087#issuecomment-422188788
+            -->
+            <mat-option *ngFor="let selectedValue of selectedValues"
+                        style="position: absolute; visibility: hidden;"
+                        [value]="selectedValue"
+            >
+              {{selectedValue.label}}
+            </mat-option>
+          </cdk-virtual-scroll-viewport>
         </ng-container>
       </mat-select>
 

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
@@ -106,8 +106,12 @@
             </ngx-mat-select-search>
           </mat-option>
 
-          <cdk-virtual-scroll-viewport [itemSize]="48" [style.height.px]="4*48" [minBufferPx]="300"
-                                       [maxBufferPx]="600">
+          <cdk-virtual-scroll-viewport
+              [itemSize]="DROPDOWN_OPTION_SIZE"
+              [style.height.px]="scrollViewportHeight"
+              [minBufferPx]="300"
+              [maxBufferPx]="600"
+          >
             <mat-option class="all-options" *cdkVirtualFor="let dropdownOption of filteredListMulti | async"
                         [value]="dropdownOption"
                         [title]="dropdownOption.label">

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
@@ -123,7 +123,6 @@
               viewport even if they are out of the current view, because otherwise they will be
               deselected when the value changes. This hack forces them to be present.
 
-              See:
               See: https://github.com/angular/components/issues/13087#issuecomment-422188788
             -->
             <mat-option *ngFor="let selectedValue of selectedValues"

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -264,8 +264,7 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
    */
   compareFn(a: DropdownOption, b: DropdownOption): boolean {
 
-    // Adding the `false` part ensures that the comparison will still return a boolean if either value is nullish
-    return (a?.id === b?.id) || false;
+    return (a?.id === b?.id);
   }
 
 

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -201,7 +201,7 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
             return item.id;
           }, this.dropdownSetOptions)
 
-          this.filteredListMulti.next(this.dropdownSetOptions.slice());
+          this.filteredListMulti.next(this.dropdownSetOptions);
         }
 
         this.checkForAttachmentUrl();
@@ -246,6 +246,16 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
 
 
   /**
+   * The function used to determine whether or not dropdown options represent the same entity
+   */
+  compareFn(a: DropdownOption, b: DropdownOption): boolean {
+
+    // Adding the `false` part ensures that the comparison will still return a boolean if either value is nullish
+    return (a?.id === b?.id) || false;
+  }
+
+
+  /**
    * Generates a tooltip for the given link
    */
   downloadableLinkTooltip(link: { fileName: string, fileUrl: string, fileId: string }): string {
@@ -273,8 +283,9 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
       let search = this.multiFilterCtrl.value;
 
       if (!search) {
-        this.filteredListMulti.next(this.dropdownSetOptions.slice());
-      } else {
+        this.filteredListMulti.next(this.dropdownSetOptions);
+      }
+      else {
         search = search.toLowerCase();
 
         // filter the list
@@ -498,6 +509,7 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
 
 
   private _setValue(): void {
+
     if (this.field.dropdownDataset?.options?.length || this.isInChildForm) {
       this.selectedValues = this.generateMultipleOptionsFromSingle();
     }

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -77,6 +77,9 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
 
   @Output() onChange = new EventEmitter<IFieldChangedEvent>();
 
+
+  DROPDOWN_OPTION_SIZE = 42;
+
   multiFilterCtrl: FormControl = new FormControl();
 
   selectedValues = [];
@@ -111,6 +114,17 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
   get rowIdIsValid(): boolean {
 
     return (this.form.rowId && this.form.rowId > -1);
+  }
+
+
+  /**
+   * Determines the height of the expanded option set. Scales up to at most four options
+   */
+  get scrollViewportHeight(): number {
+
+    const itemCount = Math.min(4, this.filteredListMulti?.value.length ?? 1);
+
+    return (itemCount * this.DROPDOWN_OPTION_SIZE);
   }
 
 

--- a/src/app/dynamic-forms/fields/link/link.component.html
+++ b/src/app/dynamic-forms/fields/link/link.component.html
@@ -94,6 +94,7 @@
     </ng-template>
     <ng-template #hierarchyWithCaption>
       {{this.field.caption}}
+
       <br /> <br />
 
       From the <b>{{ this.field.cinchyColumn.linkTargetColumnName }}</b> field in the {{ this.field.cinchyColumn.linkTableDomainName }} - {{ this.field.cinchyColumn.linkTargetTableName }} table.
@@ -120,25 +121,15 @@
             <mat-spinner diameter="35"></mat-spinner>
           </mat-option>
           <cdk-virtual-scroll-viewport *ngIf="searchCharacterLimitMet && !isLoading"
-                                       [itemSize]="48"
-                                       [style.height.px]="192">
-            <ng-container>
-              <mat-option *ngFor="let option of filteredOptions"
-                          [title]="option.label"
-                          [value]="option.label"
-                          (click)="onOptionSelected(option)">
-                {{ option.displayOnlyLabel ?? option.label ?? "" }}
-              </mat-option>
-            </ng-container>
-          </cdk-virtual-scroll-viewport>
-          <ng-container *ngIf="!searchCharacterLimitMet && !isLoading">
-            <mat-option *ngFor="let option of filteredOptions"
+                                       [itemSize]="DROPDOWN_OPTION_SIZE"
+                                       [style.height.px]="scrollViewportHeight">
+            <mat-option *cdkVirtualFor="let option of filteredOptions"
                         [title]="option.label"
                         [value]="option.label"
                         (click)="onOptionSelected(option)">
               {{ option.displayOnlyLabel ?? option.label ?? "" }}
             </mat-option>
-          </ng-container>
+          </cdk-virtual-scroll-viewport>
         </ng-container>
       </mat-autocomplete>
     </ng-container>

--- a/src/app/dynamic-forms/fields/link/link.component.ts
+++ b/src/app/dynamic-forms/fields/link/link.component.ts
@@ -88,6 +88,8 @@ export class LinkComponent implements OnChanges, OnInit {
   @Output() childForm = new EventEmitter<any>();
 
 
+  DROPDOWN_OPTION_SIZE = 48;
+
   // TODO: Add proper type
   metadataQueryResult;
 
@@ -141,6 +143,17 @@ export class LinkComponent implements OnChanges, OnInit {
   get rowIdIsValid(): boolean {
 
     return (this.form.rowId && this.form.rowId > -1);
+  }
+
+
+  /**
+   * Determines the height of the expanded option set. Scales up to at most four options
+   */
+  get scrollViewportHeight(): number {
+
+    const itemCount = Math.min(4, this.filteredOptions?.length ?? 1);
+
+    return (itemCount * this.DROPDOWN_OPTION_SIZE);
   }
 
 


### PR DESCRIPTION
When switching between filtered and unfiltered variations of option selection on a linked multi-select field with more than 2000 options, the selected options were inconsistent with the user's actual selections due to a bug with how the options that are not currently rendered in the virtual viewport interact with the material selector. This PR addresses that issue by forcing the selected options to render so that they aren't removed from the selector's set when the filter (or the fact that they are out of frame) would otherwise de-render them. Doing it this way rather than just forcing the selected options to the top of the list means that we don't have to worry about cutoff when there are a lot of selected options.

This PR also removes an issue where filtering a large set down to fewer than 4 results would render a bunch of extra blank space, The height of the option set now scales correctly to the number of options, up to 4.