### PR TITLE
CIN-01910: Date behaviour in child forms (defect resolution)

### DIFF
--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.html
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.html
@@ -59,7 +59,7 @@
                           [fieldsWithErrors]="fieldsWithErrors"
                           [formHasDataLoaded]="formHasDataLoaded"
                           (childRowDeleted)="onChildRowDeleted($event)"
-                          (childFormOpened)="openChildForm($event)"
+                          (childFormOpened)="openChildFormDialog($event)"
                           (onChange)="handleFieldsEvent($event)">
       </app-fields-wrapper>
     </mat-accordion>
@@ -69,7 +69,7 @@
                           [fieldsWithErrors]="fieldsWithErrors"
                           [formHasDataLoaded]="formHasDataLoaded"
                           (childRowDeleted)="onChildRowDeleted($event)"
-                          (childFormOpened)="openChildForm($event)"
+                          (childFormOpened)="openChildFormDialog($event)"
                           (onChange)="handleFieldsEvent($event)">
       </app-fields-wrapper>
     </ng-template>

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -535,8 +535,8 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
       const pendingItem = this._pendingChildFormQueries[recursionCounter];
 
       if (pendingItem.query.query) {
-        const queryToExecute = pendingItem.query.query.replace("{sourceid}", rowId.toString());
-        const params = JSON.parse(JSON.stringify(pendingItem.query.params).replace("{sourceId}", rowId.toString()));
+        const queryToExecute = pendingItem.query.query.replace("{parentId}", rowId.toString());
+        const params = JSON.parse(JSON.stringify(pendingItem.query.params).replace("{parentId}", rowId.toString()));
 
         this._cinchyService.executeCsql(queryToExecute, params).subscribe(
           async () => {

--- a/src/app/dynamic-forms/fields/attach-file/attach-file.component.html
+++ b/src/app/dynamic-forms/fields/attach-file/attach-file.component.html
@@ -15,13 +15,13 @@
              id="file"
              (change)="onFileSelected($event)">
 
-      <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.value">
+      <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.hasValue">
         *{{field.label}} is Required.
       </mat-error>
     </div>
   </div>
 
-  <div *ngIf="field.value">
+  <div *ngIf="field.hasValue">
     <div *ngIf="fileName" style="margin: 5px;">
       <a class="download-link" (click)="downloadDocument()">
         Existing file: <strong>{{fileName}}</strong>

--- a/src/app/dynamic-forms/fields/checkbox/checkbox.component.html
+++ b/src/app/dynamic-forms/fields/checkbox/checkbox.component.html
@@ -11,7 +11,7 @@
     &nbsp;
     <label class="pre-formatted" [for]="field.label" [title]="field.caption || ''">
       {{field.label}}
-      {{(field.cinchyColumn.isMandatory && !field.value) ? '*' : ''}}
+      {{(field.cinchyColumn.isMandatory && !field.hasValue) ? '*' : ''}}
     </label>
     <mat-icon *ngIf="field.caption" class="info-icon-checkbox"
               ngbTooltip="{{field.caption}}"
@@ -22,7 +22,7 @@
       info
     </mat-icon>
   </div>
-  <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.value">
+  <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.hasValue">
     *{{field.label}} is Required.
   </mat-error>
 </div>

--- a/src/app/dynamic-forms/fields/child-form/child-form.component.ts
+++ b/src/app/dynamic-forms/fields/child-form/child-form.component.ts
@@ -60,19 +60,33 @@ export class ChildFormComponent {
           else if (this.childFormData.presetValues) {
             // bind dropdown values
             if (field.cinchyColumn.dataType === "Link") {
-              if (!this.childFormData.presetValues[field.cinchyColumn.name]) {
+              if (
+                  !this.childFormData.presetValues[field.cinchyColumn.name] &&
+                  !this.childFormData.presetValues[field.cinchyColumn.name]?.length &&
+                  field.label === childFormLinkName
+              ) {
                 // Prefill child linked column value with parent id if the target table id matches parent form table id
-                const parentRowId = field.label === childFormLinkName ? this.childFormData.childForm.parentForm.rowId : null;
-                this.childFormData.childForm.updateFieldValue(
-                  sectionIndex,
-                  fieldIndex,
-                  parentRowId ?? null
-                );
+                let parentRowId: number =  this.childFormData.childForm.parentForm.rowId;
+
+                if (field.cinchyColumn.isMultiple) {
+                  this.childFormData.childForm.updateFieldValue(
+                    sectionIndex,
+                    fieldIndex,
+                    parentRowId ? [parentRowId.toString()] : []
+                  );
+                }
+                else {
+                  this.childFormData.childForm.updateFieldValue(
+                    sectionIndex,
+                    fieldIndex,
+                    parentRowId?.toString() ?? null
+                  );
+                }
               }
               else if (field.dropdownDataset?.options?.length) {
                 if (field.cinchyColumn.isMultiple) {
 
-                  const linkIds = this.childFormData.presetValues[field.cinchyColumn.name];
+                  const linkIds = this.childFormData.presetValues[field.cinchyColumn.name] ?? [];
 
                   // Search by ID, then label
                   let result = field.dropdownDataset.options.filter((option: DropdownOption) => {
@@ -91,7 +105,7 @@ export class ChildFormComponent {
                   let result = field.dropdownDataset.options.find((option: DropdownOption) => {
 
                     // TODO: We're explicitly using a double equals here because at this stage the ID may be either a number or string depending on where it was
-                    //       populated. In the future we'll need to figure out which is correct and make sunre we're using it consistently
+                    //       populated. In the future we'll need to figure out which is correct and make sure we're using it consistently
                     return (
                       (option.id == this.childFormData.presetValues[field.cinchyColumn.name]) ||
                       (option.label === this.childFormData.presetValues[field.cinchyColumn.name])
@@ -295,7 +309,8 @@ export class ChildFormComponent {
 
     if (formValidation.isValid) {
       this.dialogRef.close((!this.childFormData.presetValues || !this.childFormData.presetValues["Cinchy ID"]) ? -1 : this.childFormData.presetValues["Cinchy ID"]);
-    } else {
+    }
+    else {
       // TODO: this should be a toast, which means that we'd need to either dynamically inject the ToastrService or create a
       //       NotificationService with static functions to display this sort of thing
       console.error("Child form was invalid:", formValidation.message);

--- a/src/app/dynamic-forms/fields/child-form/child-form.component.ts
+++ b/src/app/dynamic-forms/fields/child-form/child-form.component.ts
@@ -61,7 +61,6 @@ export class ChildFormComponent {
             // bind dropdown values
             if (field.cinchyColumn.dataType === "Link") {
               if (
-                  !this.childFormData.presetValues[field.cinchyColumn.name] &&
                   !this.childFormData.presetValues[field.cinchyColumn.name]?.length &&
                   field.label === childFormLinkName
               ) {

--- a/src/app/dynamic-forms/fields/choice/choice.component.html
+++ b/src/app/dynamic-forms/fields/choice/choice.component.html
@@ -7,7 +7,7 @@
       &nbsp;
       <label class="cinchy-label" [title]="field.caption ?? ''">
         {{field.label}}
-        {{field.cinchyColumn.isMandatory && !field.value ? '*' : ''}}
+        {{field.cinchyColumn.isMandatory && !field.hasValue ? '*' : ''}}
       </label>
       <mat-icon *ngIf="field.caption" class="info-icon"
                 ngbTooltip="{{field.caption}}"

--- a/src/app/dynamic-forms/fields/datetime/datetime.component.html
+++ b/src/app/dynamic-forms/fields/datetime/datetime.component.html
@@ -7,7 +7,7 @@
     &nbsp;
     <label class="cinchy-label" [title]="field.caption || ''">
       {{field.label}}
-      {{(field.cinchyColumn.isMandatory && !field.value) ? '*' : ''}}
+      {{(field.cinchyColumn.isMandatory && !field.hasValue) ? '*' : ''}}
     </label>
     <mat-icon *ngIf="field.caption" class="info-icon"
               ngbTooltip="{{field.caption}}"

--- a/src/app/dynamic-forms/fields/datetime/datetime.component.ts
+++ b/src/app/dynamic-forms/fields/datetime/datetime.component.ts
@@ -85,6 +85,6 @@ export class DatetimeComponent implements OnChanges, OnInit {
 
   private _setValue(): void {
 
-    this.value = this.field?.value ? moment(this.field.value).format(this.field.cinchyColumn.displayFormat || "MM/DD/yyyy") : "";
+    this.value = this.field?.hasValue ? moment(this.field.value).format(this.field.cinchyColumn.displayFormat || "MM/DD/yyyy") : "";
   }
 }

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
@@ -8,7 +8,7 @@
         &nbsp;
         <label class="cinchy-label" [title]="field.caption || ''">
           {{field.label}}
-          {{(field.cinchyColumn.isMandatory && !field.value) ? "*" : ""}}
+          {{(field.cinchyColumn.isMandatory && !field.hasValue) ? "*" : ""}}
         </label>
 
         <mat-icon *ngIf="field.caption && field.cinchyColumn.tableId !== field.cinchyColumn.linkTargetTableId" class="info-icon"
@@ -135,7 +135,7 @@
         </ng-container>
       </mat-select>
 
-      <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.value">
+      <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.hasValue">
         *{{field.label}} is Required.
       </mat-error>
 

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -167,7 +167,7 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
     if (!this.dropdownListFromLinkedTable) {
       this.isLoading = true;
       let dropdownDataset: DropdownDataset;
-      let currentFieldJson;
+      let currentFieldJson: any;
 
       let tableColumnQuery: string = `
         SELECT
@@ -316,8 +316,10 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
       let selectedIds: Array<string>;
 
       // Fallback for legacy logic
-      if (this.field.dropdownDataset.options.length === 1 &&
-          this.field.dropdownDataset.options[0].id.includes(",")) {
+      if (
+          this.field.dropdownDataset.options.length === 1 &&
+          this.field.dropdownDataset.options[0].id.includes(",")
+      ) {
 
         selectedIds = this.field.dropdownDataset.options[0].id?.split(",").map((id: string) => id.trim());
 
@@ -329,7 +331,7 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
         });
       }
 
-      if (this.field.value) {
+      if (this.field.hasValue) {
         // Fallback for legacy logic
         if (typeof this.field.value === "string") {
           selectedIds = this.field.value.split(",").map((id: string) => id.trim() );
@@ -340,7 +342,14 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
       }
 
       if (selectedIds?.length) {
-        return selectedIds.map((id: string) => this.field.dropdownDataset.options.find((option: DropdownOption) => option.id === id ));
+        return selectedIds.map((id: string) => {
+
+          return this.field.dropdownDataset.options.find((option: DropdownOption) => {
+
+            // We're explicitly using a double equals here because at this stage the ID may be either a number or string
+            return option.id == id;
+          });
+        });
       }
     }
 

--- a/src/app/dynamic-forms/fields/link/link.component.html
+++ b/src/app/dynamic-forms/fields/link/link.component.html
@@ -7,7 +7,7 @@
       &nbsp;
       <label class="cinchy-label" [title]="field.caption ?? ' '">
         {{field.label}}
-        {{(field.cinchyColumn.isMandatory && !field.value) ? "*" : ""}}
+        {{(field.cinchyColumn.isMandatory && !field.hasValue) ? "*" : ""}}
       </label>
       <span *ngIf="canAdd">
         <a (click)="openNewOptionDialog()">
@@ -168,7 +168,7 @@
            style="margin-top: -10px">
   </ng-container>
   <mat-error class="mat-error-move-up-10"
-             *ngIf="showError && field.cinchyColumn.isMandatory && !field.value">
+             *ngIf="showError && field.cinchyColumn.isMandatory && !field.hasValue">
     *{{field.label}} is Required.
   </mat-error>
 </div>

--- a/src/app/dynamic-forms/fields/link/link.component.ts
+++ b/src/app/dynamic-forms/fields/link/link.component.ts
@@ -651,7 +651,7 @@ export class LinkComponent implements OnChanges, OnInit {
       this.getListItems(true, true);
     }
     else {
-      if (this.field.value) {
+      if (this.field.hasValue) {
         // Handles the case where there is a placeholder element (e.g. "Loading...")
         if (dataset?.length === 1) {
           this.selectedValue = { ...dataset[0] };
@@ -660,8 +660,7 @@ export class LinkComponent implements OnChanges, OnInit {
         else if (dataset?.length > 1) {
           this.selectedValue = dataset.find((option: DropdownOption) => {
 
-            // TODO: We're explicitly using a double equals here because at this stage the ID may be either a number or string depending on where it was
-            //       populated. In the future we'll need to figure out which is correct and make sunre we're using it consistently
+            // We're explicitly using a double equals here because at this stage the ID may be either a number or string
             return (option.id == this.field.value);
           });
         }

--- a/src/app/dynamic-forms/fields/multichoice/multichoice.component.html
+++ b/src/app/dynamic-forms/fields/multichoice/multichoice.component.html
@@ -9,7 +9,7 @@
         {{ field.label }}
         {{ (field.cinchyColumn.isMandatory && !value) ? '*' :'' }}
       </label>
-      <mat-icon *ngIf="field.caption" 
+      <mat-icon *ngIf="field.caption"
         class="info-icon"
         ngbTooltip="{{field.caption}}"
         placement="auto"
@@ -20,25 +20,25 @@
       </mat-icon>
     </div>
     <div class="full-width-element divMarginBottom" *ngIf="canEdit">
-      <mat-select multiple 
+      <mat-select multiple
           class="form-control"
           [(ngModel)]="value"
           [ngModelOptions]="{ standalone: true }"
           (openedChange)="resetFilter()"
           (selectionChange)="valueChanged()">
         <mat-option>
-          <ngx-mat-select-search 
+          <ngx-mat-select-search
             class="multi-search"
             [(ngModel)]="choiceFilter"
             [ngModelOptions]="{ standalone: true }"
-            [showToggleAllCheckbox]="true" 
+            [showToggleAllCheckbox]="true"
             (toggleAll)="toggleSelectAll($event)"
             placeholderLabel="Search {{ field.label }}"
             noEntriesFoundLabel="No entries matched your search">
           </ngx-mat-select-search>
         </mat-option>
 
-        <mat-option 
+        <mat-option
           *ngFor="let opt of options | filterBy: choiceFilter"
           [value]="opt">
           {{ opt }}
@@ -53,7 +53,7 @@
 
   <!-- isMandatory Validator-->
   <mat-error class="mat-error-move-up-19"
-             *ngIf="showError && (field.cinchyColumn.isMandatory && !field.value)">
+             *ngIf="showError && (field.cinchyColumn.isMandatory && !field.hasValue)">
     *{{field.label}} is Required.
   </mat-error>
 </div>

--- a/src/app/dynamic-forms/fields/number/number.component.html
+++ b/src/app/dynamic-forms/fields/number/number.component.html
@@ -6,7 +6,7 @@
     &nbsp;
     <label class="cinchy-label" [title]="field.caption || ''">
       {{field.label}}
-      {{(field.cinchyColumn.isMandatory && !field.value) ? '*' : ''}}
+      {{(field.cinchyColumn.isMandatory && !field.hasValue) ? '*' : ''}}
     </label>
     <mat-icon *ngIf="field.caption"
               class="info-icon"
@@ -29,7 +29,7 @@
            (blur)="transformAmount()"
            (focus)="reverseTransform()" />
 
-    <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.value">
+    <mat-error *ngIf="showError && field.cinchyColumn.isMandatory && !field.hasValue">
       *{{field.label}} is Required.
     </mat-error>
   </ng-container>

--- a/src/app/dynamic-forms/models/cinchy-form-field.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form-field.model.ts
@@ -36,8 +36,7 @@ export class FormField {
   get hasValue(): boolean {
 
     if (Array.isArray(this.value)) {
-
-      return coerceBooleanProperty(this.value?.length);
+      return !!(this.value && this.value.length);
     }
 
     return (!!this.value || this.value === 0);

--- a/src/app/dynamic-forms/models/cinchy-form-field.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form-field.model.ts
@@ -1,6 +1,7 @@
 import { Observable } from "rxjs";
-import { map, startWith, isEmpty } from "rxjs/operators";
+import { map, startWith } from "rxjs/operators";
 
+import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { FormControl } from "@angular/forms";
 
 import { CinchyColumn } from "./cinchy-column.model";
@@ -12,7 +13,6 @@ import { DropdownDataset } from "../service/cinchy-dropdown-dataset/cinchy-dropd
 import { DropdownOption } from "../service/cinchy-dropdown-dataset/cinchy-dropdown-options";
 
 import { isNullOrUndefined } from "util";
-import { coerceBooleanProperty } from "@angular/cdk/coercion";
 
 
 export class FormField {
@@ -27,6 +27,22 @@ export class FormField {
 
   // This is initialized to null to prevent false positives for change detection
   value: any = null;
+
+
+  /**
+   * Determines whether or not this field has what the app considers to be a value. Empty arrays
+   * in multi-select controls are considered to be non-values.
+   */
+  get hasValue(): boolean {
+
+    if (Array.isArray(this.value)) {
+
+      return coerceBooleanProperty(this.value?.length);
+    }
+
+    return (!!this.value || this.value === 0);
+  }
+
 
   constructor(
       public id: number,

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -597,14 +597,6 @@ export class Form {
                 if (field.value === "DELETE") {
                   params[paramName] = "";
                 }
-                else if (currentFieldIsLinkedColumn) {
-                  if (field.cinchyColumn.isMultiple && !field.hasValue) {
-                    params[paramName] = "[{parentId}]";
-                  }
-                  else {
-                    params[paramName] = field.value || "{parentId}";
-                  }
-                }
                 else {
                   params[paramName] = field.value?.toString();
                 }

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -384,7 +384,7 @@ export class Form {
 
           switch (field.cinchyColumn.dataType) {
             case "Date and Time":
-              params[paramName] = this._getISOStringFromDateString(field.value);
+              params[paramName] = this._getISOStringFromDateString(field.value, field.cinchyColumn.displayFormat);
 
               break;
             case "Choice":
@@ -568,7 +568,7 @@ export class Form {
 
           switch (field.cinchyColumn.dataType) {
             case "Date and Time":
-              params[paramName] = this._getISOStringFromDateString(field.value);
+              params[paramName] = this._getISOStringFromDateString(field.value, field.cinchyColumn.displayFormat);
 
               break;
             case "Choice":

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -335,7 +335,12 @@ export class Form {
     return null;
   }
 
+
+  /**
+   * Gets the column name associated with the child form link ID, if set
+   */
   getChildFormLinkName(childFormLinkId: string): string {
+
     // We only need the first segment since the linkFieldId can have a value like "[Field].[Cinchy Id]"
     return childFormLinkId?.replace(/[\[\]]+/g, "").split(".")[0];
   }
@@ -433,7 +438,7 @@ export class Form {
             assignmentColumns.push(`[${field.cinchyColumn.name}]`);
 
             if (isNullOrUndefined(field.cinchyColumn.linkTargetColumnName)) {
-              if ((field.cinchyColumn.dataType === "Text") && !field.value) {
+              if ((field.cinchyColumn.dataType === "Text") && !field.hasValue) {
                 assignmentValues.push((params[paramName] !== "") ? `cast(${paramName} as nvarchar(100))` : paramName);
               }
               else {
@@ -442,7 +447,7 @@ export class Form {
             }
             else {
               if (field.value instanceof Array || field.cinchyColumn.isMultiple) {
-                if (field.cinchyColumn.dataType === "Link" && !field.value?.length) {
+                if (field.cinchyColumn.dataType === "Link" && !field.hasValue) {
                   assignmentValues.push(`cast(${paramName} as nvarchar(100))`);
                 }
                 else {
@@ -528,16 +533,22 @@ export class Form {
     let params: { [key: string]: any } = {};
 
     this.rowId = rowId;
+
     const childFormLinkName = this.getChildFormLinkName(this.childFormLinkId);
+    let currentFieldIsLinkedColumn: boolean;
 
     this.sections.forEach((section: FormSection) => {
 
       section.fields.forEach((field: FormField) => {
 
+        currentFieldIsLinkedColumn = field.label === childFormLinkName;
+
         const isLinkedColumnForInsert = coerceBooleanProperty(
           !this.rowId &&
-          (field.cinchyColumn.dataType === "Link" ||
-            field.label === childFormLinkName)
+          (
+            (field.cinchyColumn.dataType === "Link" && field.hasValue) ||
+            currentFieldIsLinkedColumn
+          )
         );
 
         if (
@@ -547,7 +558,7 @@ export class Form {
           (field.cinchyColumn.hasChanged || isLinkedColumnForInsert)
         ) {
           paramName = `@p${paramNumber++}`;
-          foundLinkedColumn ||= field.label === childFormLinkName;
+          foundLinkedColumn ||= currentFieldIsLinkedColumn;
 
           switch (field.cinchyColumn.dataType) {
             case "Date and Time":
@@ -586,6 +597,14 @@ export class Form {
                 if (field.value === "DELETE") {
                   params[paramName] = "";
                 }
+                else if (currentFieldIsLinkedColumn) {
+                  if (field.cinchyColumn.isMultiple && !field.hasValue) {
+                    params[paramName] = "[{parentId}]";
+                  }
+                  else {
+                    params[paramName] = field.value || "{parentId}";
+                  }
+                }
                 else {
                   params[paramName] = field.value?.toString();
                 }
@@ -607,7 +626,7 @@ export class Form {
               if (isNullOrUndefined(this.rowId)) {
                 assignmentValues.push(`${paramName}`);
               }
-              else if ((field.cinchyColumn.dataType === "Text") && !field.value) {
+              else if ((field.cinchyColumn.dataType === "Text") && !field.hasValue) {
                 assignmentValues.push((params[paramName] !== "") ? `cast(${paramName} as nvarchar(100))` : paramName);
               }
               else {
@@ -615,8 +634,8 @@ export class Form {
               }
             }
             else {
-              if (field.value && field.cinchyColumn.isMultiple) {
-                if (field.cinchyColumn.dataType === "Link" && !field.value?.length) {
+              if (field.hasValue && field.cinchyColumn.isMultiple) {
+                if (field.cinchyColumn.dataType === "Link" && !field.hasValue) {
                   assignmentValues.push(`cast(${paramName} as nvarchar(100))`);
                 }
                 else {
@@ -676,6 +695,7 @@ export class Form {
     // If linked field is NOT DISPLAYED, link child record to parent table by matching the childFormLinkName
     if (!foundLinkedColumn) {
       this.tableMetadata["Columns"]?.forEach((column: { columnType: string, linkedTableId: number, name: string }) => {
+
         if (column.name === childFormLinkName) {
           paramName = `@p${paramNumber++}`;
           assignmentColumns.push(`[${column.name}]`);
@@ -683,8 +703,10 @@ export class Form {
 
           if (column.columnType === "Link") {
             params[paramName] = this.parentForm.rowId.toString();
-          } else {
+          }
+          else {
             const parentFormLinkName = this.childFormParentId?.split("].[")[0]?.replace(/[\[\]]+/g, "");
+
             params[paramName] = this.parentForm.fieldsByColumnName[parentFormLinkName].value
           }
         }
@@ -1075,7 +1097,24 @@ export class Form {
     if (this._sections?.length > sectionIndex && this._sections[sectionIndex].fields?.length > fieldIndex) {
       // Since we don't store the field's original value, we will mark it as changed if the current value is different from the
       // value immediately prior, or if the field has already been marked as changed
-      const valueIsDifferent = (newValue !== this._sections[sectionIndex].fields[fieldIndex].value);
+      let valueIsDifferent: boolean;
+
+      if (Array.isArray(newValue)) {
+        valueIsDifferent = (newValue?.length !== this._sections[sectionIndex].fields[fieldIndex].value?.length);
+
+        if (!valueIsDifferent) {
+          for (let index = 0; index < newValue?.length; index++) {
+            if (newValue[index] !== this._sections[sectionIndex].fields[fieldIndex].value[index]) {
+              valueIsDifferent = true;
+
+              break;
+            }
+          }
+        }
+      }
+      else {
+        valueIsDifferent = (newValue !== this._sections[sectionIndex].fields[fieldIndex].value);
+      }
 
       this.hasChanged = this.hasChanged || valueIsDifferent;
 

--- a/src/app/dynamic-forms/service/print/print.service.ts
+++ b/src/app/dynamic-forms/service/print/print.service.ts
@@ -22,6 +22,8 @@ import { ToastrService } from "ngx-toastr";
 import pdfMake from "pdfmake/build/pdfmake";
 import pdfFonts from "pdfmake/build/vfs_fonts";
 
+import * as moment from "moment/moment";
+
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 
@@ -711,18 +713,21 @@ export class PrintService {
       this.content.push({ columns: this._getLinkColumns(fieldCopy, "Open") });
     }
     else if (fieldCopy.cinchyColumn.dataType === "Date and Time") {
-      let stringDate = fieldCopy.value;
+      if (fieldCopy.value) {
+        const dateAsMoment = moment(fieldCopy.value);
 
-      try {
-        if (fieldCopy.value) {
-          stringDate = this._datePipe.transform(fieldCopy.value, "MMM/dd/yyyy")
+        if (dateAsMoment.isValid) {
+          this.content.push({
+            columns: this._getFieldColumns(fieldCopy, dateAsMoment.format(fieldCopy.cinchyColumn.displayFormat || "MM/DD/yyyy"))
+          });
         }
-      } catch (e) {
-        console.error("Error converting date:", fieldCopy.value)
-      }
 
-      this.content.push({ columns: this._getFieldColumns(fieldCopy, stringDate) });
-    } else {
+      }
+      else {
+        this.content.push({ columns: this._getFieldColumns(fieldCopy) });
+      }
+    }
+    else {
       this.content.push({ columns: this._getFieldColumns(fieldCopy) });
     }
   }

--- a/src/app/dynamic-forms/service/print/print.service.ts
+++ b/src/app/dynamic-forms/service/print/print.service.ts
@@ -505,7 +505,7 @@ export class PrintService {
         }
       );
     }
-    else if (!field.value) {
+    else if (!field.hasValue) {
       returnValues.push({
         text: "-",
         style: "fieldValue"
@@ -545,7 +545,7 @@ export class PrintService {
     if (this._isHtmlAnchor(field.value)) {
       returnValues.push(this._generateAnchorArrayItemFromHtml(field.value, null, "Open"));
     }
-    else if (!field.value) {
+    else if (!field.hasValue) {
       returnValues.push(
         {
           text: "-",


### PR DESCRIPTION
This suite of changes fixes a number of bugs with child forms that were preventing testing of child form dates for ticket #CIN-01910.

- Link fields and multi-select link fields will no longer be marked as changed  by default
- Child forms with multi-select link columns as their foreign key will now successfully prepopulate the selected record as their foreign key
- Attempting to add a row to a child table on a form in create mode (i.e. no selected record) will no longer attempt to save the form immediately, and will actually bring up the child form dialog, and when the parent form is saved, the rowId that gets generated will correctly propagate to the child forms as they are saved