### PR TITLE
CIN-08469: Newly-added child records duplicate when edited before the parent is saved

### DIFF
--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -50,9 +50,6 @@ import { PrintService } from "./service/print/print.service";
 import { SearchDropdownComponent } from "../shared/search-dropdown/search-dropdown.component";
 
 
-const INITIAL_TEMPORARY_CINCHY_ID: number = -2;
-
-
 @Component({
   selector: "cinchy-dynamic-forms",
   templateUrl: "./cinchy-dynamic-forms.component.html",
@@ -125,17 +122,6 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
    * set is cleared (as those queries are no longer pending)
    */
   private _pendingChildFormQueries = new Array<IChildFormQuery>();
-
-  /**
-   * In the event that we are adding a record to a child form, the query gets generated and then mapped to a temporary
-   * cinchy ID so that it can be referenced later if the newly-added record is modified before the form is saved. This
-   * temporary ID is sequential and increasingly-negative to avoid relying on something like Math.random() which could
-   * easily result in a duplicate.
-   *
-   * Since -1 is the initial placeholder ID that indicates that the incoming record is an add instead of an edit, we're
-   * starting this variable at -2.
-   */
-  private _lastTemporaryCinchyId: number = INITIAL_TEMPORARY_CINCHY_ID;
 
 
   constructor(
@@ -232,7 +218,6 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
     this.form = this.form.clone();
 
     this._pendingChildFormQueries = new Array<IChildFormQuery>();
-    this._lastTemporaryCinchyId = INITIAL_TEMPORARY_CINCHY_ID;
 
     this.form.restoreFormReferenceOnAllFields();
     this._appStateService.setRecordSelected(null, true);
@@ -472,7 +457,9 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
 
         let childFormRowValues = targetChildForm.childForm.childFormRowValues || [];
 
-        const newValues: { [key: string]: any } = {};
+        const newValues: { [key: string]: any } = {
+          "Cinchy ID": resultId
+        };
         const childFormLinkName = data.childForm.getChildFormLinkName(data.childForm.childFormLinkId);
 
         data.childForm.sections.forEach((section: FormSection, sectionIndex: number) => {
@@ -487,9 +474,18 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
               if (field.cinchyColumn.isDisplayColumn) {
                 const columnLabel = `${field.cinchyColumn.linkTargetColumnName} label`;
                 // When a linked column value is changed, we are not able to update the display column,
-                // So if the linked column value has changed, update the display column values to "-". 
-                const linkedColumn = section.fields.find((f: FormField) => field.cinchyColumn.id === f.cinchyColumn.id && !f.cinchyColumn.isDisplayColumn);
-                if (isEqual(sortBy(toString(linkedColumn.value)), sortBy(toString(data.presetValues[linkedColumn.label])))) {
+                // So if the linked column value has changed, update the display column values to "-".
+                const linkedColumnField: FormField = section.fields.find(
+                  (field: FormField) => {
+
+                    return (
+                      field.cinchyColumn.id === field.cinchyColumn.id &&
+                      !field.cinchyColumn.isDisplayColumn
+                    )
+                  }
+                );
+
+                if (isEqual(sortBy(toString(linkedColumnField.value)), sortBy(toString(data.presetValues[linkedColumnField.label])))) {
                   newValues[columnLabel] = data.presetValues[columnLabel];
                 }
                 else {
@@ -506,13 +502,10 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
         const rowDataIndex = childFormRowValues.findIndex((rowData: { [key: string]: any }) => rowData["Cinchy ID"] === resultId);
 
         if (rowDataIndex > -1) {
-          newValues["Cinchy ID"] = resultId;
           childFormRowValues.splice(rowDataIndex, 1, newValues);
         }
         else {
-          childFormRowValues.push(
-            Object.assign(newValues, { "Cinchy ID": this._lastTemporaryCinchyId-- })
-          );
+          childFormRowValues.push(newValues);
         }
 
         // TODO: this only works because the presetValues are directly mutated in the ChildFormComponent, which is not a pattern
@@ -583,7 +576,6 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
 
             if (this._pendingChildFormQueries.length === (recursionCounter + 1)) {
               this._pendingChildFormQueries = new Array<IChildFormQuery>();
-              this._lastTemporaryCinchyId = INITIAL_TEMPORARY_CINCHY_ID;
 
               await this.loadForm();
               this._toastr.success("Child form saved successfully", "Success");

--- a/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.html
+++ b/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.html
@@ -1,10 +1,9 @@
 <div *ngIf="field?.childForm" class="full-width-element">
-  <!-- Child form table header -->
   <span class="error-message" *ngIf="!childForm.tableEntitlements.accessIsDefinedForCurrentUser">
-    You don't have access to this table
+    You don't have permission to view the child form {{ childForm.name }}.
   </span>
   <div class="mat-header-child">
-    {{ childForm.sections[0].label }}
+    {{ childForm.name || childForm.sections[0].label }}
 
     <span class="text-left" *ngIf="childForm.tableEntitlements.canAddRows">
       <a (click)="addChildRecord(childForm.sections[0].label)">
@@ -12,45 +11,49 @@
       </a>
     </span>
   </div>
-  <!-- Child form table Row header -->
   <div class="table-responsive" *ngIf="childForm.childFormRowValues?.length">
     <table class="table child-table">
       <thead>
         <tr>
           <th class="mat-row-child">Action</th>
           <ng-container *ngFor="let key of fieldKeys">
-            <!-- Child form dynamic table Row header -->
             <th *ngIf="cellShouldBeDisplayed(key)">
               {{ getTableHeader(key) }}
             </th>
           </ng-container>
         </tr>
       </thead>
-      <!-- Child form dynamic table Row Data -->
       <tbody>
-        <tr *ngFor="let rowData of childForm.childFormRowValues; let rowIndex = index" class="pre-formatted">
-          <!-- Edit Child form  -->
-          <td class="action-width">
-            <a class="btn-dynamic-child primary btnForm" *ngIf="childForm.tableEntitlements.accessIsDefinedForCurrentUser" (click)="editChildRecord(childForm.sections[0].label, rowData)">
-              <fa-icon [icon]="faEdit"></fa-icon>
-            </a>
-            <a class="btn-dynamic-child warn btnForm" *ngIf="childForm.tableEntitlements.canDeleteRows"
-                (click)="deleteRow(rowData)">
-              <fa-icon [icon]="faTrash"></fa-icon>
-            </a>
-          </td>
-          <ng-container *ngFor="let key of fieldKeys">
-            <td *ngIf="cellShouldBeDisplayed(key)"
-                [ngStyle]="childFieldDictionary[key]?.cinchyColumn?.doNotWrap ? { 'white-space': 'nowrap' } : ''"
-                [innerHTML]="getDisplayValue(rowIndex, key)">
+        <ng-container *ngFor="let rowData of childForm.childFormRowValues; let rowIndex = index">
+          <tr class="pre-formatted">
+            <td class="action-width">
+              <a class="btn-dynamic-child primary btnForm"
+                  *ngIf="childForm.tableEntitlements.accessIsDefinedForCurrentUser"
+                  (click)="editChildRecord(childForm.sections[0].label, rowData)"
+              >
+                <fa-icon [icon]="faEdit"></fa-icon>
+              </a>
+              <a class="btn-dynamic-child warn btnForm"
+                  *ngIf="childForm.tableEntitlements.canDeleteRows"
+                  (click)="deleteRow(rowData)"
+              >
+                <fa-icon [icon]="faTrash"></fa-icon>
+              </a>
             </td>
-          </ng-container>
-        </tr>
+            <ng-container *ngFor="let key of fieldKeys">
+              <td *ngIf="cellShouldBeDisplayed(key)"
+                  [ngStyle]="childFieldDictionary[key]?.cinchyColumn?.doNotWrap ? { 'white-space': 'nowrap' } : ''"
+                  [innerHTML]="getDisplayValue(rowIndex, key)"
+              >
+              </td>
+            </ng-container>
+          </tr>
+        </ng-container>
       </tbody>
     </table>
   </div>
-  <p *ngIf="childForm.childFormLinkId == null || childForm.childFormParentId == null ;else noRecord"> 
-     The columns "Child Form Link Field" or both the "Child Form Parent ID" and the "Child Form Link ID" must be populated in your form fields table. 
+  <p *ngIf="childForm.childFormLinkId == null || childForm.childFormParentId == null ;else noRecord">
+     The columns "Child Form Link Field" or both the "Child Form Parent ID" and the "Child Form Link ID" must be populated in your form fields table.
   </p>
   <ng-template #noRecord>
     <p *ngIf="!childForm.childFormRowValues?.length">

--- a/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.html
+++ b/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.html
@@ -1,9 +1,13 @@
 <div *ngIf="field?.childForm" class="full-width-element">
-  <span class="error-message" *ngIf="!childForm.tableEntitlements.accessIsDefinedForCurrentUser">
-    You don't have permission to view the child form {{ childForm.name }}.
-  </span>
+  <div class="error-message" *ngIf="!childForm.tableEntitlements.accessIsDefinedForCurrentUser">
+    You don't have permission to view the child form
+
+    <span *ngIf="childForm.sections[0]">
+      {{ childForm.sections[0].label }}
+    </span>
+  </div>
   <div class="mat-header-child">
-    {{ childForm.name || childForm.sections[0].label }}
+    {{ childForm.sections[0].label }}
 
     <span class="text-left" *ngIf="childForm.tableEntitlements.canAddRows">
       <a (click)="addChildRecord(childForm.sections[0].label)">
@@ -52,13 +56,14 @@
       </tbody>
     </table>
   </div>
-  <p *ngIf="childForm.childFormLinkId == null || childForm.childFormParentId == null ;else noRecord">
+
+  <p *ngIf="(!childForm.childFormLinkId || !childForm.childFormParentId); else noRecord">
      The columns "Child Form Link Field" or both the "Child Form Parent ID" and the "Child Form Link ID" must be populated in your form fields table.
   </p>
+
   <ng-template #noRecord>
     <p *ngIf="!childForm.childFormRowValues?.length">
       There is no data in this table. You can use the add button above to get started.
     </p>
   </ng-template>
-
 </div>

--- a/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
+++ b/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
@@ -166,17 +166,17 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
 
     // Find lowest negative Cinchy ID (these are all new records) so that we can generate a new one
     let lowestCinchyId = 0;
+
     this.childForm.childFormRowValues?.forEach(rowVal => {
       if (rowVal["Cinchy ID"] < lowestCinchyId) {
         lowestCinchyId = rowVal["Cinchy ID"];
       }
     });
-    lowestCinchyId--;
 
     this.childFormOpened.emit(
       {
         childForm: this.childForm,
-        presetValues: { "Cinchy ID": lowestCinchyId },
+        presetValues: { "Cinchy ID": lowestCinchyId - 1 },
         title: dialogTitle
       }
     );
@@ -193,7 +193,7 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
     }
 
     return coerceBooleanProperty(
-      (key !== "Cinchy ID") &&
+      (key.toLowerCase() !== "cinchy id") &&
       (!this.field.isLinkedColumn(key)) &&
       (this.childFieldDictionary[key]?.cinchyColumn?.dataType !== "Binary")
     );

--- a/src/app/dynamic-forms/fields/child-form/child-form.component.ts
+++ b/src/app/dynamic-forms/fields/child-form/child-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
 import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 
 import { DropdownDatasetService } from "../../service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service";
@@ -10,7 +10,6 @@ import { FormSection } from "../../models/cinchy-form-section.model";
 
 import { DropdownDataset } from "../../service/cinchy-dropdown-dataset/cinchy-dropdown-dataset";
 
-import { isNullOrUndefined } from "util";
 import { IFieldChangedEvent } from "../../interface/field-changed-event";
 
 
@@ -24,7 +23,7 @@ import { IFieldChangedEvent } from "../../interface/field-changed-event";
   styleUrls: ["./child-form.component.scss"],
   providers: [DropdownDatasetService]
 })
-export class ChildFormComponent {
+export class ChildFormComponent implements OnInit {
 
   constructor(
     public dialogRef: MatDialogRef<ChildFormComponent>,

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
@@ -129,7 +129,7 @@
                         style="position: absolute; visibility: hidden;"
                         [value]="selectedValue"
             >
-              {{selectedValue.label}}
+              {{ selectedValue?.label }}
             </mat-option>
           </cdk-virtual-scroll-viewport>
         </ng-container>

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -323,12 +323,11 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
       // Fallback for legacy logic
       if (
           this.field.dropdownDataset.options.length === 1 &&
-          this.field.dropdownDataset.options[0].id.includes(",")
+          this.field.dropdownDataset.options[0].id?.includes(",")
       ) {
-
         selectedIds = this.field.dropdownDataset.options[0].id?.split(",").map((id: string) => id.trim());
 
-        this.field.dropdownDataset.options = this.field.dropdownDataset.options[0].label.split(",").map((label: string, index: number) => {
+        this.field.dropdownDataset.options = this.field.dropdownDataset.options[0].label?.split(",").map((label: string, index: number) => {
           return new DropdownOption(
             selectedIds[index],
             label.trim()

--- a/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
+++ b/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
@@ -237,8 +237,8 @@ export class FormHelperService {
           if (!isNullOrUndefined(formFields[i].linkFieldId)) {
             let linkField = childFormFieldsMetadata.find(field => field.formFieldId == formFields[i].linkFieldId);
             if (linkField) {
-              parentColumnNameForLinkingToChild = "[Cinchy Id]";
-              childFormColumnNameForLinkingToParent = `[${linkField.columnName}].[Cinchy Id]`;
+              parentColumnNameForLinkingToChild = "[Cinchy ID]";
+              childFormColumnNameForLinkingToParent = `[${linkField.columnName}].[Cinchy ID]`;
             }
           }
 


### PR DESCRIPTION
Author or reviewer, don’t forget the [guidelines](https://cinchy.visualstudio.com/Cinchy/_wiki/wikis/Cinchy.wiki/448/Pull-Requests).

---

# Overview

If adding a new record to a child form using the ChildFormTableComponent, attempting to edit said record before the parent form was saved would cause a separate version of that record to be added with the new values, leaving the old version in place. This is a fix to that problem so that the child records behave as expected

# Details

The issue was caused by the temporary Cinchy ID being stripped from the record when it was opened to be edited, so when the data was passed back it would have a new value set to the next available temporary Cinchy ID. We needed to correct the logic around generating the IDs, as well as how the record was handled after the edit operation to preserve the ID and ensure that the new data would be associated with the same record.

# Risk

Negligible. Only the logic for temporary Cinchy IDs on child form records was changed, and the new version is objectively more stable since we are no longer trying to perform this operation in two different ways.

# Testing

Steps to reproduce prior in old version:
- On a form with a ChildFormTableComponent, add a new row to the table with any valid set of values and save
- Click the edit button on the newly-created row, change any values, and save with a valid set of values
- Both the original version of the record and the new version of the record will now be present in the table, and saving the parent form will save both versions as separate records to the child table. After the fix is applied, you should instead see just the new values in the table, and only those values will be persisted when the parent form is saved.

# Docs

## Release notes

Bug fix: Editing a child form record that has not yet been added to the child table will no longer create duplicate values

## Change log

- The CinchyDynamicFormsComponent is no longer responsible for managing temporary Cinchy IDs on newly-added records
- The Form model was updated so that changes to a child form record would be sufficient to mark the parent form as dirty, thus allowing the parent form to be saved with no further changes
