### PR TITLE
CIN-08600: auth redirect fix

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,23 +6,16 @@ import { FormWrapperComponent } from "./pages/form-wrapper/form-wrapper.componen
 
 const routes: Routes = [
   {
-    path: "",
-    redirectTo: "edit-form",
-    pathMatch: "full"
-  },
-  {
-    path: "edit-form",
+    path: "**",
     component: FormWrapperComponent
   }
 ];
 
+
 @NgModule({
   imports: [
     RouterModule.forRoot(
-      routes,
-      {
-        relativeLinkResolution: "legacy"
-      }
+      routes
     )
   ],
   exports: [

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -105,12 +105,10 @@ export class AppComponent implements OnDestroy, OnInit {
     // Ensure that the window's location is stable before trying to access the query params
     setTimeout(
       async () => {
+
         this.setRowAndFormId();
 
         this.loginDone = true;
-
-        await this.router.navigate(["/edit-form"], { queryParamsHandling: "merge" });
-
       },
       1
     );

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,4 @@
-import { Subscription } from "rxjs";
-
-import { Component, OnDestroy, OnInit } from "@angular/core";
-import { Router } from "@angular/router";
+import { Component, OnInit } from "@angular/core";
 
 import { CinchyService } from "@cinchy-co/angular-sdk";
 
@@ -13,25 +10,15 @@ import { AppStateService } from "./services/app-state.service";
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"]
 })
-export class AppComponent implements OnDestroy, OnInit {
+export class AppComponent implements OnInit {
 
   loginDone: boolean;
 
 
-  private _routerEventSubscription: Subscription
-
-
   constructor(
-      private router: Router,
       private cinchyService: CinchyService,
       private appStateService: AppStateService
   ) {}
-
-
-  ngOnDestroy(): void {
-
-    this._routerEventSubscription.unsubscribe();
-  }
 
 
   ngOnInit(): void {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -62,18 +62,13 @@ export class AppComponent implements OnDestroy, OnInit {
    * @returns The value of the "rowId" query parameter from the given URI as a number. If the rowId
    *          is invalid or unset, will will return null instead.
    */
-  getRowIdFromUriOrSession(uri: string): number {
+  getRowIdFromUri(uri: string): number {
 
     let idAsString: string;
     let idAsNumber: number;
 
     if (uri) {
       idAsString = this.getQueryStringValue("rowId", uri);
-    }
-
-    // Reverting session logic to triage first-load issues
-    if (!idAsString && localStorage.getItem("cinchy-rowId")) {
-      idAsString = localStorage.getItem("cinchy-rowId");
     }
 
     if (idAsString) {
@@ -136,6 +131,6 @@ export class AppComponent implements OnDestroy, OnInit {
     const resolvedUri: string = parentUri?.toLowerCase().includes("formid") ? parentUri : uri;
 
     this.appStateService.setRootFormId(this.getQueryStringValue("formId", resolvedUri));
-    this.appStateService.setRecordSelected(this.getRowIdFromUriOrSession(resolvedUri), false);
+    this.appStateService.setRecordSelected(this.getRowIdFromUri(resolvedUri), false);
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Subscription } from "rxjs";
 
-import { NavigationStart, Router, RouterEvent } from "@angular/router";
-import { Component, HostListener, OnDestroy, OnInit} from "@angular/core";
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
 
 import { CinchyService } from "@cinchy-co/angular-sdk";
 
@@ -25,18 +25,7 @@ export class AppComponent implements OnDestroy, OnInit {
       private router: Router,
       private cinchyService: CinchyService,
       private appStateService: AppStateService
-  ) {
-
-    this._routerEventSubscription = this.router.events.subscribe({
-      next: (event: RouterEvent) => {
-
-        // This is used if the incoming URL causes an immediate reload which would otherwise destroy the queryparams
-        if (event instanceof NavigationStart && !this.loginDone) {
-          this.setRowAndFormId();
-        }
-      }
-    });
-  }
+  ) {}
 
 
   ngOnDestroy(): void {
@@ -83,8 +72,8 @@ export class AppComponent implements OnDestroy, OnInit {
     }
 
     // Reverting session logic to triage first-load issues
-    if (!idAsString && sessionStorage.getItem("rowId")) {
-      idAsString = sessionStorage.getItem("rowId");
+    if (!idAsString && localStorage.getItem("cinchy-rowId")) {
+      idAsString = localStorage.getItem("cinchy-rowId");
     }
 
     if (idAsString) {
@@ -107,12 +96,7 @@ export class AppComponent implements OnDestroy, OnInit {
    */
   getQueryStringValue(key: string, uri: string): string {
 
-    const value = decodeURIComponent(uri.replace(new RegExp("^(?:.*[&\\?]" + encodeURIComponent(key).replace(/[\.\+\*]/g, "\\$&") + "(?:\\=([^&]*))?)?.*$", "i"), "$1"));
-
-    // Covers the case where there is an ID stored in the session but the queryString explicitly requests to clear it
-    if (value === "null") {
-      sessionStorage.removeItem(key);
-    }
+    const value: string = decodeURIComponent(uri.replace(new RegExp("^(?:.*[&\\?]" + encodeURIComponent(key).replace(/[\.\+\*]/g, "\\$&") + "(?:\\=([^&]*))?)?.*$", "i"), "$1"));
 
     return (value && value !== "null") ? value : null;
   }
@@ -123,14 +107,18 @@ export class AppComponent implements OnDestroy, OnInit {
    */
   loadRoute(): void {
 
-    // This will be the second call to this function if the router catches an involuntary redirect,
-    // but will be the first call if the entry URL is correctly formed and the session doesn't need
-    // to refresh
-    this.setRowAndFormId();
+    // Ensure that the window's location is stable before trying to access the query params
+    setTimeout(
+      async () => {
+        this.setRowAndFormId();
 
-    this.loginDone = true;
+        this.loginDone = true;
 
-    this.router.navigate(["/edit-form"], { queryParamsHandling: "merge" });
+        await this.router.navigate(["/edit-form"], { queryParamsHandling: "merge" });
+
+      },
+      1
+    );
   }
 
 
@@ -139,27 +127,15 @@ export class AppComponent implements OnDestroy, OnInit {
    */
   setRowAndFormId(): void {
 
-    const uri = window.location.search;
-    const parentUri = (window.location === window.parent.location) ? window.location.search : window.parent.location.search;
+    const uri: string = window.location.search;
+    const parentUri: string = (window.location === window.parent.location) ? window.location.search : window.parent.location.search;
 
     // If the app is embedded, it's possible that the querystring can be passed in through the parent's queryParams, so we need to check to
     // see if the formId is present there, and then use those if that is the case. If the app is not embedded, or if the parent instead sets
     // the embedded frame's target using the querystring, then we use this window's queryParams instead
-    const resolvedUri = parentUri?.toLowerCase().includes("formid") ? parentUri : uri;
+    const resolvedUri: string = parentUri?.toLowerCase().includes("formid") ? parentUri : uri;
 
-    let formId: string = this.getQueryStringValue("formId", resolvedUri)?.toString();
-
-    // Reverting session logic to triage first-load issues
-    if (formId) {
-      sessionStorage.setItem("formId", formId);
-    }
-    else {
-      formId = sessionStorage.getItem("formId");
-
-      window.location.href += `${window.location.search?.length ? "&" : "?"}formId=${formId}`;
-    }
-
-    this.appStateService.setRootFormId(formId);
+    this.appStateService.setRootFormId(this.getQueryStringValue("formId", resolvedUri));
     this.appStateService.setRecordSelected(this.getRowIdFromUriOrSession(resolvedUri), false);
   }
 }

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -124,9 +124,6 @@ export class AppStateService {
       doNotReloadForm: doNotReloadForm
     });
 
-    // Reverting session logic to triage first-load issues
-    sessionStorage.setItem("rowId", rowId ? rowId.toString() : "");
-
     if (rowId === null) {
       this.deleteRowIdInQueryParams();
     }

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -87,6 +87,8 @@ export class AppStateService {
 
       const [key, value] = paramString.split("=");
 
+      // Because the key here will be an empty string in the case the queryParams are empty or malformed,
+      // we explicitly need to check that it is truthy. Optional chaining would yield a false position
       if (key && key.toLowerCase() !== "rowid") {
         return `${key}=${value}`;
       }
@@ -155,6 +157,8 @@ export class AppStateService {
 
       const [key, value] = paramString.split("=");
 
+      // Because the key here will be an empty string in the case the queryParams are empty or malformed,
+      // we explicitly need to check that it is truthy. Optional chaining would yield a false position
       if (key && key.toLowerCase() !== "rowid") {
         return `${key}=${value}`;
       }

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -82,12 +82,12 @@ export class AppStateService {
 
     window.parent.postMessage(message, "*");
 
-    // Modifies the app"s URL
+    // Modifies the app's URL
     const queryParams = window.location.search?.substr(1).split("&").map((paramString: string) => {
 
       const [key, value] = paramString.split("=");
 
-      if (key.toLowerCase() !== "rowid") {
+      if (key && key.toLowerCase() !== "rowid") {
         return `${key}=${value}`;
       }
     }).join("");
@@ -124,6 +124,9 @@ export class AppStateService {
       doNotReloadForm: doNotReloadForm
     });
 
+    // Reverting session logic to triage first-load issues
+    sessionStorage.setItem("rowId", rowId ? rowId.toString() : "");
+
     if (rowId === null) {
       this.deleteRowIdInQueryParams();
     }
@@ -155,7 +158,7 @@ export class AppStateService {
 
       const [key, value] = paramString.split("=");
 
-      if (key.toLowerCase() !== "rowid") {
+      if (key && key.toLowerCase() !== "rowid") {
         return `${key}=${value}`;
       }
     }).join("");
@@ -164,6 +167,9 @@ export class AppStateService {
       const baseUrl = window.location.href.substr(0, window.location.href.indexOf("?"));
 
       window.history.replaceState(window.history.state, document.title, `${baseUrl}?${queryParams}&${rowIdQueryString}`);
+    }
+    else {
+      window.history.replaceState(window.history.state, document.title, `${window.location.href}?${rowIdQueryString}`);
     }
   }
 }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -23,9 +23,9 @@ export class ConfigService {
 
   get envConfig(): CinchyConfig {
 
-    return this._enviornmentConfig;
+    return this._environmentConfig;
   }
-  private _enviornmentConfig: CinchyConfig;
+  private _environmentConfig: CinchyConfig;
 
 
   constructor(
@@ -35,8 +35,8 @@ export class ConfigService {
 
     window.addEventListener("message", this.receiveMessage, false);
 
-    if (localStorage.getItem("fullScreenHeight")) {
-      IframeUtil.setFrameHeight(localStorage.getItem("fullScreenHeight"));
+    if (localStorage.getItem("cinchy-fullScreenHeight")) {
+      IframeUtil.setFrameHeight(localStorage.getItem("cinchy-fullScreenHeight"));
     }
   }
 
@@ -56,7 +56,7 @@ export class ConfigService {
         tap(
           (configResponse) => {
 
-            this._enviornmentConfig = configResponse;
+            this._environmentConfig = configResponse;
           }
         ),
         concatMap(

--- a/src/app/util/iframe-util.ts
+++ b/src/app/util/iframe-util.ts
@@ -26,7 +26,7 @@ export class IframeUtil {
 
     IframeUtil._fullScreenHeight = value;
 
-    localStorage.setItem("fullScreenHeight", value || "");
+    localStorage.setItem("cinchy-fullScreenHeight", value || "");
 
     const elements = document.getElementsByClassName("full-height-element");
 


### PR DESCRIPTION
Author or reviewer, don’t forget the [guidelines](https://cinchy.visualstudio.com/Cinchy/_wiki/wikis/Cinchy.wiki/448/Pull-Requests).

---

# Overview

The initial load after and SDK redirect when accessing the Forms applet directly was not correctly rendering the form.

# Details

It was discovered that this was related to the timing of when the queryParams were reinserted, so as a temporary solution a slight delay was introduced. This ensures that the NavigationEnd event fully resolves before the metadata is loaded.

# Risk

Any 3rd-party applets created by customers will face the same issue with timing, and so the fix here would need to be replicated in their applications if they leverage queryParams in the `app.component.ts` file the same way that Forms does, meaning this is not a robust long-term solution to the problem. We will need to make the change at the SDK level and ensure that there are no side effects.

# Testing

This problem only surfaces if the applet is loaded directly via the URL -- not when it is loaded by the Cinchy applet wrapper at /Applets. If you are able to successfully log in from a fresh session to the application directly when viewed this way and load the form without a refresh, then the test was successful.

# Docs

## Release notes

- Users should no longer experience a blank page after logging in to the application
- The application no longer has a strict requirement on the path after the base URL, and no longer redirects to /edit-form by default. Any path after the baseUrl is now considered valid, and will successfully load the Angular application

## Change log

- In order to avoid the blank page on login, users will need to implement a timeout around any usage of queryParams in the `app.component.ts` file of their own angular solutions