### PR TITLE
CIN-08614: Support for manipulating data in multiple child forms on the same parent form

### DIFF
--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -543,9 +543,6 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
 
       const pendingItem: IChildFormQuery = this._pendingChildFormQueries[recursionCounter];
 
-      // DEBUG
-      console.log(pendingItem);
-
       if (pendingItem.query.query) {
         const queryToExecute = pendingItem.query.query.replace("{parentId}", rowId.toString());
         const params = JSON.parse(JSON.stringify(pendingItem.query.params).replace("{parentId}", rowId.toString()));

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -462,7 +462,7 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
 
     dialogRef.afterClosed().subscribe(
       {
-        next: (resultId: number) => {
+        next: (resultId: number): void => {
 
           if (resultId) {
             const targetChildForm: IFindChildFormResponse = this.form.findChildForm(data.childForm.id);
@@ -472,9 +472,9 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
             };
             const childFormLinkName: string = data.childForm.getChildFormLinkName(data.childForm.childFormLinkId);
 
-            data.childForm.sections.forEach((section: FormSection, sectionIndex: number) => {
+            data.childForm.sections.forEach((section: FormSection, sectionIndex: number): void => {
 
-              section.fields.forEach((field: FormField, fieldIndex: number) => {
+              section.fields.forEach((field: FormField, fieldIndex: number): void => {
 
                 if (
                   field.cinchyColumn.hasChanged ||
@@ -482,15 +482,16 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
                   (field.label === childFormLinkName)
                 ) {
                   if (field.cinchyColumn.isDisplayColumn) {
-                    const columnLabel = `${field.cinchyColumn.linkTargetColumnName} label`;
+                    const columnLabel: string = `${field.cinchyColumn.linkTargetColumnName} label`;
+
                     // When a linked column value is changed, we are not able to update the display column,
                     // So if the linked column value has changed, update the display column values to "-".
                     const linkedColumnField: FormField = section.fields.find(
-                      (field: FormField) => {
+                      (linkedField: FormField) => {
 
                         return (
-                          field.cinchyColumn.id === field.cinchyColumn.id &&
-                          !field.cinchyColumn.isDisplayColumn
+                          field.cinchyColumn.id === linkedField.cinchyColumn.id &&
+                          !linkedField.cinchyColumn.isDisplayColumn
                         )
                       }
                     );
@@ -530,7 +531,7 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
   }): void {
 
     this._pendingChildFormQueries = this._pendingChildFormQueries.filter(
-      (query: IChildFormQuery) => {
+      (query: IChildFormQuery): boolean => {
 
         return ((query.childFormId !== data.childForm.id) || (query.rowId !== data.rowId));
       }

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -38,6 +38,7 @@ import { ILookupRecord } from "../models/lookup-record.model";
 import { IChildFormQuery } from "./interface/child-form-query";
 import { IExportSettings } from "./interface/export-settings";
 import { IFieldChangedEvent } from "./interface/field-changed-event";
+import { IFindChildFormResponse } from "./interface/find-child-form-response";
 import { INewEntityDialogResponse } from "./interface/new-entity-dialog-response";
 
 import { AppStateService } from "../services/app-state.service";
@@ -48,7 +49,6 @@ import { FormHelperService } from "./service/form-helper/form-helper.service";
 import { PrintService } from "./service/print/print.service";
 
 import { SearchDropdownComponent } from "../shared/search-dropdown/search-dropdown.component";
-import {IFindChildFormResponse} from "./interface/find-child-form-response";
 
 
 @Component({

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -350,84 +350,97 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
         form.populateSectionsFromFormMetadata(this.formSectionsMetadata);
 
         this._cinchyQueryService.getFormFieldsMetadata(this.formId).subscribe(
-          async (formFieldsMetadata: Array<IFormFieldMetadata>) => {
+          {
+            next: async (formFieldsMetadata: Array<IFormFieldMetadata>) => {
 
-            if (this.lookupRecordsListPopulated) {
-              const selectedLookupRecord = this.lookupRecordsList.find((record: ILookupRecord) => {
+              if (this.lookupRecordsListPopulated) {
+                const selectedLookupRecord = this.lookupRecordsList.find((record: ILookupRecord) => {
 
-                return (record.id === this.rowId);
-              });
+                  return (record.id === this.rowId);
+                });
 
-              await this._formHelperService.fillWithFields(form, this.rowId, this.formMetadata, formFieldsMetadata, selectedLookupRecord, tableEntitlements);
+                await this._formHelperService.fillWithFields(form, this.rowId, this.formMetadata, formFieldsMetadata, selectedLookupRecord, tableEntitlements);
 
-              if (selectedLookupRecord){
-                const success = await this._formHelperService.fillWithData(form, this.rowId, selectedLookupRecord, null, null);
+                if (selectedLookupRecord){
+                  const success: boolean = await this._formHelperService.fillWithData(form, this.rowId, selectedLookupRecord, null, null);
 
-                if (success && form.childFieldsLinkedToColumnName?.length) {
-                  // Update the value of the child fields that are linked to a parent field (only for flattened child forms)
-                  for (let parentColumnName in form.childFieldsLinkedToColumnName) {
-                    let linkedParentField = form.fieldsByColumnName[parentColumnName];
-                    let linkedChildFields = form.childFieldsLinkedToColumnName[parentColumnName] || [];
+                  if (success && form.childFieldsLinkedToColumnName?.length) {
+                    // Update the value of the child fields that are linked to a parent field (only for flattened child forms)
+                    for (let parentColumnName in form.childFieldsLinkedToColumnName) {
+                      let linkedParentField: FormField = form.fieldsByColumnName[parentColumnName];
+                      let linkedChildFields: Array<FormField> = form.childFieldsLinkedToColumnName[parentColumnName] || [];
 
-                    for (let linkedChildField of linkedChildFields) {
-                      // Skip non-flat child forms and skip if there's already a value or if it already matches the parent's value
-                      if (!linkedChildField.form.flatten || linkedChildField.value || linkedParentField.value === linkedChildField.value) {
-                        continue;
+                      for (let linkedChildField of linkedChildFields) {
+                        // Skip non-flat child forms and skip if there's already a value or if it already matches the parent's value
+                        if (!linkedChildField.form.flatten || linkedChildField.value || linkedParentField.value === linkedChildField.value) {
+                          continue;
+                        }
+
+                        // Update the child form field's value
+                        const fieldIndex: number = form.sections[0].fields.findIndex((field: FormField) => {
+
+                          return (field.id === linkedChildField.id);
+                        });
+
+                        form.updateFieldValue(
+                          0,
+                          fieldIndex,
+                          linkedParentField.value
+                        );
+
+                        this.afterChildFormEdit(linkedChildField.form.rowId, linkedChildField.form);
                       }
-
-                      // Update the child form field's value
-                      const fieldIndex = form.sections[0].fields.findIndex((field: FormField) => {
-
-                        return (field.id === linkedChildField.id);
-                      });
-
-                      form.updateFieldValue(
-                        0,
-                        fieldIndex,
-                        linkedParentField.value
-                      );
-
-                      this.afterChildFormEdit(linkedChildField.form.rowId, linkedChildField.form);
                     }
                   }
                 }
+
+                this.form = form;
+
+                this.enableSaveBtn = true;
+
+                this._formIsLoading = false;
+                this.formHasDataLoaded = true;
+
+                await this._spinner.hide();
+
+                if (childData) {
+                  setTimeout(() => {
+
+                    this._appStateService.parentFormSavedFromChild$.next(childData);
+                  }, 500);
+                }
               }
+            },
+            error: (error: any) => {
 
-              this.form = form;
-
-              this.enableSaveBtn = true;
+              this._spinner.hide();
 
               this._formIsLoading = false;
-              this.formHasDataLoaded = true;
 
-              await this._spinner.hide();
-
-              if (childData) {
-                setTimeout(() => {
-
-                  this._appStateService.parentFormSavedFromChild$.next(childData);
-                }, 500);
-              }
+              console.error(error);
             }
-          },
-          error => {
-
-            this._spinner.hide();
-            this._formIsLoading = false;
-
-            console.error(error);
-          });
-      } catch (e) {
+          }
+        );
+      }
+      catch (error: any) {
         await this._spinner.hide();
 
         this._formIsLoading = false;
 
-        console.error(e);
+        console.error(error);
       }
     }
   }
 
 
+  /**
+   * Opens the dialog to add or edit a record in the context of a child form table. When the dialog is saved, the
+   * desired values are structured and inserted into the appropriate child form and passed along for post processing
+   *
+   * @param data Contains a reference to the target childForm, any previous values for the target record, a title for
+   *        the dialog, and whether or not the view should be restricted to only those fields specified by the form
+   *        field's metadata
+   */
   async openChildFormDialog(
       data: {
         childForm: Form,
@@ -436,10 +449,6 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
         title: string
       }
   ): Promise<void> {
-
-    if (data.presetValues["Cinchy ID"]) {
-      data.childForm.rowId = data.presetValues["Cinchy ID"];
-    }
 
     data.useLimitedFields = true;
 
@@ -451,60 +460,64 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
       }
     );
 
-    dialogRef.afterClosed().subscribe((resultId: number) => {
+    dialogRef.afterClosed().subscribe(
+      {
+        next: (resultId: number) => {
 
-      if (!isNullOrUndefined(resultId)) {
-        const targetChildForm: IFindChildFormResponse = this.form.findChildForm(data.childForm.id);
+          if (resultId) {
+            const targetChildForm: IFindChildFormResponse = this.form.findChildForm(data.childForm.id);
 
-        const newValues: { [key: string]: any } = {
-          "Cinchy ID": resultId
-        };
-        const childFormLinkName: string = data.childForm.getChildFormLinkName(data.childForm.childFormLinkId);
+            const newValues: { [key: string]: any } = {
+              "Cinchy ID": resultId
+            };
+            const childFormLinkName: string = data.childForm.getChildFormLinkName(data.childForm.childFormLinkId);
 
-        data.childForm.sections.forEach((section: FormSection, sectionIndex: number) => {
+            data.childForm.sections.forEach((section: FormSection, sectionIndex: number) => {
 
-          section.fields.forEach((field: FormField, fieldIndex: number) => {
+              section.fields.forEach((field: FormField, fieldIndex: number) => {
 
-            if (
-              field.cinchyColumn.hasChanged ||
-              (data.presetValues && data.presetValues["Cinchy ID"] > 0) ||
-              (field.label === childFormLinkName)
-            ) {
-              if (field.cinchyColumn.isDisplayColumn) {
-                const columnLabel = `${field.cinchyColumn.linkTargetColumnName} label`;
-                // When a linked column value is changed, we are not able to update the display column,
-                // So if the linked column value has changed, update the display column values to "-".
-                const linkedColumnField: FormField = section.fields.find(
-                  (field: FormField) => {
+                if (
+                  field.cinchyColumn.hasChanged ||
+                  (data.presetValues && data.presetValues["Cinchy ID"] > 0) ||
+                  (field.label === childFormLinkName)
+                ) {
+                  if (field.cinchyColumn.isDisplayColumn) {
+                    const columnLabel = `${field.cinchyColumn.linkTargetColumnName} label`;
+                    // When a linked column value is changed, we are not able to update the display column,
+                    // So if the linked column value has changed, update the display column values to "-".
+                    const linkedColumnField: FormField = section.fields.find(
+                      (field: FormField) => {
 
-                    return (
-                      field.cinchyColumn.id === field.cinchyColumn.id &&
-                      !field.cinchyColumn.isDisplayColumn
-                    )
+                        return (
+                          field.cinchyColumn.id === field.cinchyColumn.id &&
+                          !field.cinchyColumn.isDisplayColumn
+                        )
+                      }
+                    );
+
+                    if (isEqual(sortBy(toString(linkedColumnField.value)), sortBy(toString(data.presetValues[linkedColumnField.label])))) {
+                      newValues[columnLabel] = data.presetValues[columnLabel];
+                    }
+                    else {
+                      newValues[columnLabel] = "-";
+                    }
                   }
-                );
-
-                if (isEqual(sortBy(toString(linkedColumnField.value)), sortBy(toString(data.presetValues[linkedColumnField.label])))) {
-                  newValues[columnLabel] = data.presetValues[columnLabel];
+                  else {
+                    newValues[field.cinchyColumn.name] = field.value;
+                  }
                 }
-                else {
-                  newValues[columnLabel] = "-";
-                }
-              }
-              else {
-                newValues[field.cinchyColumn.name] = field.value;
-              }
-            }
-          });
-        });
+              });
+            });
 
-        targetChildForm.childForm.addOrModifyChildFormRowValue(newValues);
+            targetChildForm.childForm.addOrModifyChildFormRowValue(newValues);
 
-        this._appStateService.childRecordUpdated$.next();
+            this._appStateService.childRecordUpdated$.next();
 
-        this.afterChildFormEdit(resultId, data.childForm);
+            this.afterChildFormEdit(resultId, data.childForm);
+          }
+        }
       }
-    });
+    );
   }
 
 

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -198,7 +198,7 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
 
       const existingQueryIndex = this._pendingChildFormQueries?.findIndex((query: IChildFormQuery) => {
 
-        return (query.rowId === childRowId);
+        return ((query.childFormId === targetChildForm.id) && (query.rowId === childRowId));
       });
 
       if (existingQueryIndex > -1) {
@@ -487,7 +487,7 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
               if (field.cinchyColumn.isDisplayColumn) {
                 const columnLabel = `${field.cinchyColumn.linkTargetColumnName} label`;
                 // When a linked column value is changed, we are not able to update the display column,
-                // So if the linked column value has changed, update the display column values to "-". 
+                // So if the linked column value has changed, update the display column values to "-".
                 const linkedColumn = section.fields.find((f: FormField) => field.cinchyColumn.id === f.cinchyColumn.id && !f.cinchyColumn.isDisplayColumn);
                 if (isEqual(sortBy(toString(linkedColumn.value)), sortBy(toString(data.presetValues[linkedColumn.label])))) {
                   newValues[columnLabel] = data.presetValues[columnLabel];

--- a/src/app/dynamic-forms/fields-wrapper/fields-wrapper.component.ts
+++ b/src/app/dynamic-forms/fields-wrapper/fields-wrapper.component.ts
@@ -54,8 +54,7 @@ export class FieldsWrapperComponent {
   @Output() onChange = new EventEmitter<IFieldChangedEvent>();
   @Output() childRowDeleted = new EventEmitter<{
     childForm: Form,
-    rowId: number,
-    sectionIndex: number
+    rowId: number
   }>();
   @Output() childFormOpened = new EventEmitter<any>();
 

--- a/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
+++ b/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
@@ -200,6 +200,14 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
   }
 
 
+  /**
+   * Removes the given row from the table. If the row is not temporary (i.e. has a valid Cinchy ID which corresponds to
+   * an existing record), then it is deleted immediately if the user confirms their intent to do so. Otherwise the
+   * target record will be spliced from the set of pending queries. In both cases, the deletion is broadcast to the
+   * parent components via the childRowDeleted emitter.
+   *
+   * @param rowData The whole data of the target row
+   */
   deleteRow(rowData: { [key: string]: any }): void {
 
     if (!rowData["Cinchy ID"]) {
@@ -281,6 +289,12 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
   }
 
 
+  /**
+   * Returns the display value for the given column and the given record
+   *
+   * @param rowIndex The rowId of the target record
+   * @param key The target column
+   */
   getDisplayValue(rowIndex: number, key: string): string {
 
     return this.displayValueSet[rowIndex][key] ?? "--";
@@ -343,6 +357,11 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
   }
 
 
+  /**
+   * Returns the label for the given column to be displayed in the table
+   *
+   * @param key The field key
+   */
   getTableHeader(key: string): string {
 
     let currentField: FormField = this._childFormService.getFieldByKey(this.fieldSet, key);
@@ -361,6 +380,13 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
   }
 
 
+  /**
+   * Triggers the deletion of the given record, updates the table view, and then notifies the user that the operation
+   * was successful
+   *
+   * @param rowData Record data to be deleted
+   * @private
+   */
   private _deleteRowValue(rowData: { [key: string]: any }): void {
 
     this.childForm.deleteChildFormRowValue(rowData["Cinchy ID"]);
@@ -374,6 +400,11 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
   }
 
 
+  /**
+   * Maps the cinchy column of each field to the FormField it represents
+   *
+   * @private
+   */
   private _setChildFieldDictionary(): void {
 
     this.form.sections.forEach((section: FormSection) => {

--- a/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
+++ b/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
@@ -149,10 +149,7 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
     this._appStateService.childRecordUpdated$.pipe(
       takeUntil(this._destroy$)
     ).subscribe({
-      next: () => {
-
-        // DEBUG
-        console.log("childRecordUpdated", this.childForm.id);
+      next: (): void => {
 
         this.loadFieldKeysAndPopulateDisplayValues();
       }
@@ -168,7 +165,7 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
     await this._updateEntitlements();
 
     // Find lowest negative Cinchy ID (these are all new records) so that we can generate a new one
-    let lowestCinchyId = 0;
+    let lowestCinchyId: number = 0;
 
     this.childForm.childFormRowValues?.forEach(rowVal => {
       if (rowVal["Cinchy ID"] < lowestCinchyId) {

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
@@ -129,7 +129,7 @@
                         style="position: absolute; visibility: hidden;"
                         [value]="selectedValue"
             >
-              {{ selectedValue?.label }}
+              {{selectedValue?.label}}
             </mat-option>
           </cdk-virtual-scroll-viewport>
         </ng-container>

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -142,7 +142,7 @@ export class Form {
     const existingRowIndex: number = this.getChildFormRowIndexByRowId(rowData["Cinchy ID"]);
 
     if (existingRowIndex !== -1) {
-      this.childFormRowValues.splice(existingRowIndex, 1, [rowData]);
+      this.childFormRowValues.splice(existingRowIndex, 1, rowData);
     }
     else {
       this.childFormRowValues.push(rowData);

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -135,24 +135,20 @@ export class Form {
   /**
    * Modifies the flattened child form records by either updating an existing entry that matches the given rowId or adding a new entry if no match is present
    */
-  addOrModifyChildFormRowValue(sectionIndex: number, rowData: { [columnName: string]: any }): void {
+  addOrModifyChildFormRowValue(rowData: { [columnName: string]: any }): void {
 
-    if (rowData["Cinchy ID"] && rowData["Cinchy ID"] > 0) {
-      const existingRowIndex = this.childFormRowValues.findIndex((existingRecordData: { [columnName: string]: any }) => {
+    this.childFormRowValues = this.childFormRowValues ?? new Array<{ [key: string]: any }>();
 
-        return (existingRecordData.rowId === rowData["Cinchy ID"]);
-      });
+    const existingRowIndex: number = this.getChildFormRowIndexByRowId(rowData["Cinchy ID"]);
 
-      if (existingRowIndex !== -1) {
-        this.childFormRowValues.splice(existingRowIndex, 1, [rowData]);
-      }
-      else {
-        this.childFormRowValues.push(rowData);
-      }
+    if (existingRowIndex !== -1) {
+      this.childFormRowValues.splice(existingRowIndex, 1, [rowData]);
     }
     else {
       this.childFormRowValues.push(rowData);
     }
+
+    this.hasChanged = true;
   }
 
 
@@ -312,22 +308,43 @@ export class Form {
 
 
   /**
-   * Searches the form's fields to find a reference to a specific child forn
+   * Removes the record with the given rowId from the set of child form row values
+   *
+   * @param rowId The rowId of the record to remove
+   * @returns true if a record was successfully removed, false if the record was not found
+   */
+  deleteChildFormRowValue(rowId: number): boolean {
+
+    const existingRecordIndex: number = this.getChildFormRowIndexByRowId(rowId);
+
+    if (existingRecordIndex > -1) {
+      this.childFormRowValues.splice(existingRecordIndex, 1);
+
+      this.hasChanged = true;
+
+      // DEBUG
+      console.log(`deleted ${rowId} from`, this.childFormRowValues);
+
+      return true;
+    }
+
+    return false;
+  }
+
+
+  /**
+   * Searches the form's fields to find a reference to a specific child form
    */
   findChildForm(targetChildFormId: string): IFindChildFormResponse {
 
-    if (this._sections?.length) {
-      for (let sectionIndex = 0; sectionIndex < this._sections.length; sectionIndex++) {
-        if (this._sections[sectionIndex].fields?.length) {
-          for (let fieldIndex = 0; fieldIndex < this._sections[sectionIndex].fields.length; fieldIndex++) {
-            if (this._sections[sectionIndex].fields[fieldIndex].childForm?.id === targetChildFormId) {
-              return {
-                childForm: this._sections[sectionIndex].fields[fieldIndex].childForm,
-                fieldIndex: fieldIndex,
-                sectionIndex: sectionIndex
-              };
-            }
-          }
+    for (let sectionIndex = 0; sectionIndex < this._sections?.length; sectionIndex++) {
+      for (let fieldIndex = 0; fieldIndex < this._sections[sectionIndex].fields?.length; fieldIndex++) {
+        if (this._sections[sectionIndex].fields[fieldIndex].childForm?.id === targetChildFormId) {
+          return {
+            childForm: this._sections[sectionIndex].fields[fieldIndex].childForm,
+            fieldIndex: fieldIndex,
+            sectionIndex: sectionIndex
+          };
         }
       }
     }
@@ -346,12 +363,12 @@ export class Form {
   }
 
 
-  generateDeleteQuery(): IQuery {
+  generateDeleteQuery(targetId?: number): IQuery {
 
     return new Query(
       `DELETE
         FROM [${this.targetTableDomain}].[${this.targetTableName}]
-        WHERE [Cinchy ID] = ${this.rowId}
+        WHERE [Cinchy ID] = ${targetId ?? this.rowId}
           AND [Deleted] IS NULL`,
       null
     );
@@ -830,6 +847,21 @@ export class Form {
   }
 
 
+  /**
+   * @param rowId The rowId of the target entity
+   * @returns The index of the childFormRowValues set with data matching the given rowId, or -1 if no such row exists
+   */
+  getChildFormRowIndexByRowId(rowId: number): number {
+
+    return this.childFormRowValues?.findIndex(
+      (rowData: { [columnName: string]: any }): boolean => {
+
+        return (rowData["Cinchy ID"] === rowId);
+      }
+    ) ?? -1;
+  }
+
+
   getFileNameAndItsTable(field: FormField, childCinchyId?: number): {
       childCinchyId: number,
       column: string,
@@ -1140,6 +1172,8 @@ export class Form {
    * Updates a specific property on the main form object. Should be used in place of directly assigning any value
    */
   updateRootProperty(property: IAdditionalProperty): void {
+
+    this.hasChanged = this.hasChanged || this._valuesAreDifferent(property.propertyValue, this[property.propertyName]);
 
     this[property.propertyName] = property.propertyValue;
   }

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -322,9 +322,6 @@ export class Form {
 
       this.hasChanged = true;
 
-      // DEBUG
-      console.log(`deleted ${rowId} from`, this.childFormRowValues);
-
       return true;
     }
 

--- a/src/app/dynamic-forms/models/cinchy-query.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-query.model.ts
@@ -1,3 +1,4 @@
+// TODO: remove this pattern -- unify to a single entity
 export interface IQuery {
   query: string;
   params: { [key: string]: any };
@@ -5,6 +6,9 @@ export interface IQuery {
 }
 
 export class Query implements IQuery {
-  constructor(public query: string, public params: { [key: string]: any }, public attachedFilesInfo?) {
-  }
+  constructor(
+    public query: string,
+    public params: { [key: string]: any },
+    public attachedFilesInfo?: any
+  ) {}
 }


### PR DESCRIPTION
Author or reviewer, don’t forget the [guidelines](https://cinchy.visualstudio.com/Cinchy/_wiki/wikis/Cinchy.wiki/448/Pull-Requests).

---

# Overview

When adding records to multiple child forms in the same view, the application was experiencing collisions that lead to data loss.

# Details

The way that the app was managing the pending child records did not take into account the formId of the entity, so whenever the set was processed it would encounter the same temporary id (which was tracked for each ChildFormTable individually) and incorrectly determine that the first one it encountered was the correct target.

# Risk

Low. From a stability standpoint this is a big improvement, but a number of files were touched and the process of interacting with the child form tables involves event bubbling through multiple components. There's always a chance something was missed.

# Testing

Steps to reproduce prior in old version:
- On a form with two child forms, add a record to the first child form
- Add a record to the second child form
- Save the parent form. Only the addition to the second child form will have resolved

# Docs

## Release notes

Bug fix: Manipulating multiple child forms on the same parent form will no longer result in data loss

## Change log

N/A