### PR TITLE
CIN-09080: Incorrect section highlighted in sidenav

### DIFF
--- a/src/app/core/sidenav/sidenav.component.html
+++ b/src/app/core/sidenav/sidenav.component.html
@@ -6,7 +6,7 @@
     <div class="sidenav-option">
       <div class="mt-10">
         <ul>
-          <li *ngFor="let section of formSectionsMetadata" (click)="sectionClicked(section)">
+          <li *ngFor="let section of formSectionsMetadata" (click)="sectionClicked(section, true)">
             <div class="bullet-point" [class.bullet-point--selected]="isSelected(section.name)"></div>
             <span class="section-item" [class.section-item--selected]="isSelected(section.name)">
               {{section.name}}

--- a/src/app/core/sidenav/sidenav.component.html
+++ b/src/app/core/sidenav/sidenav.component.html
@@ -2,9 +2,6 @@
   <div class="sidenav-options">
     <h6 class="m-b-10">
       Form Sections
-
-      <!-- DEBUG -->
-      <div>selectedSection: {{ selectedSection }}</div>
     </h6>
     <div class="sidenav-option">
       <div class="mt-10">

--- a/src/app/core/sidenav/sidenav.component.html
+++ b/src/app/core/sidenav/sidenav.component.html
@@ -2,6 +2,9 @@
   <div class="sidenav-options">
     <h6 class="m-b-10">
       Form Sections
+
+      <!-- DEBUG -->
+      <div>selectedSection: {{ selectedSection }}</div>
     </h6>
     <div class="sidenav-option">
       <div class="mt-10">

--- a/src/app/core/sidenav/sidenav.component.ts
+++ b/src/app/core/sidenav/sidenav.component.ts
@@ -1,4 +1,4 @@
-import { debounceTime } from "rxjs/operators";
+import { throttleTime } from "rxjs/operators";
 
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 
@@ -55,9 +55,9 @@ export class SidenavComponent implements OnInit {
 
   ngOnInit(): void {
 
-    // This has the potential to fire multiple times when the form first loads
+    // This has the potential to fire multiple times when the form first loads if auto-expand is enabled
     this._appStateService.currentSection$.pipe(
-      debounceTime(300)
+      throttleTime(100)
     ).subscribe((sectionLabel: string) => {
 
       this.selectedSection = sectionLabel ?? this.selectedSection;
@@ -66,7 +66,7 @@ export class SidenavComponent implements OnInit {
 
     // When the section metadata is loaded, save it and expand the first section by default
     this._appStateService.latestRenderedSections$.pipe(
-      debounceTime(300)
+      throttleTime(100)
     ).subscribe((sectionMetadata: Array<IFormSectionMetadata>) => {
 
       this.formSectionsMetadata = sectionMetadata;
@@ -129,6 +129,7 @@ export class SidenavComponent implements OnInit {
   sectionClicked(section: IFormSectionMetadata): void {
 
     this.selectedSection = section.name;
+
     const sectionElement = document.getElementById(`section-${section.name}`);
     const expansionHeader: any = sectionElement ? sectionElement.children[0] : null;
     const expansionContent: any = sectionElement ? sectionElement.children[1] : null;

--- a/src/app/core/sidenav/sidenav.component.ts
+++ b/src/app/core/sidenav/sidenav.component.ts
@@ -60,7 +60,16 @@ export class SidenavComponent implements OnInit {
       throttleTime(100)
     ).subscribe((sectionLabel: string) => {
 
-      this.selectedSection = sectionLabel ?? this.selectedSection;
+      const targetSection = this.formSectionsMetadata.find(
+        (metadata: IFormSectionMetadata) => {
+
+          return (metadata.name === sectionLabel);
+        }
+      );
+
+      if (targetSection) {
+        this.sectionClicked(targetSection, false);
+      }
     });
 
 
@@ -70,10 +79,6 @@ export class SidenavComponent implements OnInit {
     ).subscribe((sectionMetadata: Array<IFormSectionMetadata>) => {
 
       this.formSectionsMetadata = sectionMetadata;
-
-      if (this.formSectionsMetadata?.length) {
-        this.sectionClicked(this.formSectionsMetadata[0]);
-      }
     });
   }
 
@@ -126,7 +131,7 @@ export class SidenavComponent implements OnInit {
    *
    * @param section the metadata of the clicked section
    */
-  sectionClicked(section: IFormSectionMetadata): void {
+  sectionClicked(section: IFormSectionMetadata, expand: boolean): void {
 
     this.selectedSection = section.name;
 
@@ -135,7 +140,7 @@ export class SidenavComponent implements OnInit {
     const expansionContent: any = sectionElement ? sectionElement.children[1] : null;
     const isHidden = expansionContent?.style?.visibility === "hidden";
 
-    if (expansionHeader && isHidden) {
+    if (expansionHeader && isHidden && expand) {
       expansionHeader.click();
       expansionHeader.focus();
     }


### PR DESCRIPTION
Due to an interaction with the auto-expand functionality, the default selected section (intended to be the first section of the form) was resolving to the last section of the form. By using throttle instead of debounce, the view will now prioritize the first interaction when the form loads, so the actual behaviour will match up with the expected behaviour.

Note that this will focus the first _expanded_ section of the form. If no sections have autoexpand set, then there will be no highlighted section in the sidenav, and if there is a highlighted section is may not necessarily be the first section of the form. This is intentional.