### PR TITLE
CIN-09125: Ensure error changes and 5.10.1 fixes work together

### DIFF
--- a/src/app/core/sidenav/sidenav.component.ts
+++ b/src/app/core/sidenav/sidenav.component.ts
@@ -1,4 +1,5 @@
-import { throttleTime } from "rxjs/operators";
+import { Subject } from "rxjs";
+import { debounceTime, throttleTime } from "rxjs/operators";
 
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 
@@ -15,8 +16,6 @@ import { AppStateService } from "../../services/app-state.service";
 import { DialogService } from "../../services/dialog.service";
 
 import { NgxSpinnerService } from "ngx-spinner";
-import {NotificationService} from "../../services/notification.service";
-import {ErrorService} from "../../services/error.service";
 
 
 @Component({
@@ -30,12 +29,25 @@ export class SidenavComponent implements OnInit {
   @Input() formMetadata: IFormMetadata;
 
 
-  @Output() closeSideBar = new EventEmitter<any>();
+  @Output() closeSideBar: EventEmitter<void> = new EventEmitter();
 
 
-  formSectionsMetadata: IFormSectionMetadata[] = [];
-  selectedSection: string;
+  formSectionsMetadata: Array<IFormSectionMetadata> = new Array<IFormSectionMetadata>();
+
   toggleMenu: boolean;
+
+
+  /**
+   * The name of the section that was most recently determined to have been selected
+   */
+  private _selectedSection: string;
+
+  /**
+   * By using a subject to set the selected section asynchronously, we can add a debounce which prevents an
+   * ExpressionChangedAfterItHasBeenCheckedError that would otherwise fire as the application initializes or the set
+   * of available sections changes
+   */
+  private _selectedSection$: Subject<string> = new Subject<string>();
 
 
   /**
@@ -50,17 +62,16 @@ export class SidenavComponent implements OnInit {
   constructor(
     private _appStateService: AppStateService,
     private _dialogService: DialogService,
-    private _errorService: ErrorService,
     private _formHelperService: FormHelperService,
-    private _notificationService: NotificationService,
     private _spinnerService: NgxSpinnerService
   ) {}
 
 
   ngOnInit(): void {
 
-    // This has the potential to fire multiple times when the form first loads if auto-expand is enabled
-    this._appStateService.currentSection$.pipe(
+    // This has the potential to fire multiple times when the form first loads if auto-expand is enabled. We're using
+    // throttle instead of debounce so that we can ensure the first open section is selected by default
+    this._appStateService.sectionExpanded$.pipe(
       throttleTime(100)
     ).subscribe((sectionLabel: string) => {
 
@@ -79,22 +90,30 @@ export class SidenavComponent implements OnInit {
 
     // When the section metadata is loaded, save it and expand the first section by default
     this._appStateService.latestRenderedSections$.pipe(
-      throttleTime(100)
+      debounceTime(100)
     ).subscribe((sectionMetadata: Array<IFormSectionMetadata>) => {
 
       this.formSectionsMetadata = sectionMetadata;
     });
+
+
+    // We're using debounce instead of throttle here because it's most correct to use the latest value
+    this._selectedSection$.pipe(
+      debounceTime(100)
+    ).subscribe(
+      {
+        next: (targetSection: string): void => {
+
+          this._selectedSection = targetSection;
+        }
+      }
+    )
   }
 
 
-  /**
-   * Determines whether or not the given section is the active section
-   *
-   * @param targetSection The name of the given section
-   */
-  isSelected(targetSection: string): boolean {
+  isSelected(section: string): boolean {
 
-    return (this.selectedSection === targetSection);
+    return (section === this._selectedSection);
   }
 
 
@@ -133,10 +152,11 @@ export class SidenavComponent implements OnInit {
    * Handles the expansion of a selected section
    *
    * @param section the metadata of the clicked section
+   * @param expand determines whether or not the section should be opened in the main viewport
    */
   sectionClicked(section: IFormSectionMetadata, expand: boolean): void {
 
-    this.selectedSection = section.name;
+    this._selectedSection$.next(section.name);
 
     const sectionElement = document.getElementById(`section-${section.name}`);
     const expansionHeader: any = sectionElement ? sectionElement.children[0] : null;

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.html
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.html
@@ -9,8 +9,8 @@
         </span>
       </a>
 
-      <app-search-dropdown #recordDropdown *ngIf="lookupRecordsList?.length"
-                           [items]="lookupRecordsList"
+      <app-search-dropdown #recordDropdown *ngIf="lookupRecords?.length"
+                           [items]="lookupRecords"
                            [selectedOption]="currentRow"
                            (dropdownClicked)="rowSelected($event)"
                            (onFilter)="handleOnFilter($event)">

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.html
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.html
@@ -31,11 +31,11 @@
           <mat-icon>add_circle</mat-icon>
           <span>Create</span>
         </button>
-        <button mat-menu-item [disabled]="!rowId" (click)="cloneFormData()">
+        <button mat-menu-item [disabled]="!form?.rowId" (click)="cloneFormData()">
           <mat-icon>content_copy</mat-icon>
           <span>Duplicate</span>
         </button>
-        <button mat-menu-item [disabled]="!rowId" (click)="copyWindowUrl()">
+        <button mat-menu-item [disabled]="!form?.rowId" (click)="copyWindowUrl()">
           <mat-icon>content_paste</mat-icon>
           <span>Copy link</span>
         </button>
@@ -49,7 +49,7 @@
         </a>
       </mat-menu>
 
-      <button type="button" mat-raised-button class="btnSave have-brand center-vertical-important" (click)="saveForm(form, rowId)" [disabled]="!enableSaveBtn">Save</button>
+      <button type="button" mat-raised-button class="btnSave have-brand center-vertical-important" (click)="saveForm(form)" [disabled]="!enableSaveBtn">Save</button>
     </div>
   </div>
 

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -1,3 +1,5 @@
+import { takeUntil } from "rxjs/operators";
+
 import {
   Component,
   EventEmitter,
@@ -48,7 +50,6 @@ import { FormHelperService } from "./service/form-helper/form-helper.service";
 import { PrintService } from "./service/print/print.service";
 
 import { SearchDropdownComponent } from "../shared/search-dropdown/search-dropdown.component";
-import {takeUntil} from "rxjs/operators";
 
 
 @Component({

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -697,7 +697,7 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
 
                   this._spinnerService.hide();
 
-                  if (!this.form.rowId) {
+                  if (!this.form?.rowId) {
                     // Technically this will also be done by the setRecordSelected handlers, but by doing it manually now we can use this immediately and won't
                     // need to wait for it to propagate
                     formData.updateRootProperty(
@@ -808,13 +808,13 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
   ): Promise<void> {
 
     if (this._pendingChildFormQueries?.length) {
-      await this.saveChildForm(this.form.rowId, 0);
+      await this.saveChildForm(this.form?.rowId, 0);
     }
     else {
       await this._spinnerService.hide();
 
-      if (!!this.form.rowId && childData) {
-        await this.loadForm(this.form?.rowId, childData);
+      if (!!this.form?.rowId && childData) {
+        await this.loadForm(this.form.rowId, childData);
       }
 
       if (!response) {
@@ -838,11 +838,11 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
             UPDATE t
             SET t.[${fileDetails.column}] = @p0
             FROM [${fileDetails.domain}].[${fileDetails.table}] t
-            WHERE t.[Cinchy ID] = ${childCinchyId ? childCinchyId : this.form.rowId}
+            WHERE t.[Cinchy ID] = ${childCinchyId ? childCinchyId : this.form?.rowId}
               AND t.[Deleted] IS NULL`;
 
           const updateParams: any = {
-            "@rowId": childCinchyId ? childCinchyId : this.form.rowId,
+            "@rowId": childCinchyId ? childCinchyId : this.form?.rowId,
             "@fieldValue": fileDetails.value
           };
 
@@ -857,7 +857,7 @@ export class CinchyDynamicFormsComponent implements OnInit, OnChanges {
           const query: string = `UPDATE t
                          SET t.[${fileDetails.column}] = @p0
                          FROM [${fileDetails.domain}].[${fileDetails.table}] t
-                         WHERE t.[Cinchy ID] = ${this.form.rowId}
+                         WHERE t.[Cinchy ID] = ${this.form?.rowId}
                           AND t.[Deleted] IS NULL;`;
 
           await this._cinchyService.executeCsql(query, params).toPromise();

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -143,13 +143,21 @@ export class CinchyDynamicFormsComponent implements OnInit {
 
   ngOnInit(): void {
 
-    this._loadLookupRecords("", this.form?.rowId);
+    // DEBUG
+    // console.log("calling _loadLookupRecords from ngOnInit");
+
+    // this._loadLookupRecords("", this.form?.rowId);
 
     this._appStateService.onRecordSelected$.subscribe(
       (record: { rowId: number | null, doNotReloadForm: boolean }): void => {
 
+        // DEBUG
+        console.log("onRecordSelected$", record, this.lookupRecordsListPopulated, this.lookupRecords);
+
         if (this.lookupRecordsListPopulated) {
           this._handleRecordSelection(record);
+
+          this._queuedRecordSelection = null;
         }
         else {
           this._queuedRecordSelection = record;
@@ -343,6 +351,9 @@ export class CinchyDynamicFormsComponent implements OnInit {
     if (resolvedFilter && this.formMetadata.lookupFilter) {
       resolvedFilter += ` AND ${this.formMetadata.lookupFilter}`;
     }
+
+    // DEBUG
+    console.log("calling _loadLookupRecords from handleOnFilter");
 
     this._loadLookupRecords(resolvedFilter ?? this.formMetadata.lookupFilter);
   }
@@ -701,6 +712,9 @@ export class CinchyDynamicFormsComponent implements OnInit {
                       }
                     );
 
+                    // DEBUG
+                    console.log("calling _loadLookupRecords from saveForm");
+
                     this._loadLookupRecords("", this.form.rowId);
 
                     this._updateFilteredTableUrl(this.form.rowId);
@@ -808,6 +822,10 @@ export class CinchyDynamicFormsComponent implements OnInit {
       {
         next: async (response: Array<ILookupRecord>): Promise<void> => {
 
+          // DEBUG
+          console.log("_loadLookupRecords", response);
+          console.log(this._queuedRecordSelection, rowIdToSelect, this.form?.rowId);
+
           this.lookupRecords = this.checkNoRecord(response);
 
           await this._handleRecordSelection(
@@ -818,8 +836,6 @@ export class CinchyDynamicFormsComponent implements OnInit {
           if (!this.formHasDataLoaded) {
             await this.loadForm(this.form?.rowId);
           }
-
-          this._queuedRecordSelection = null;
         },
         error: async (error: any): Promise<void> => {
 

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -294,26 +294,32 @@ export class CinchyDynamicFormsComponent implements OnInit {
     ) {
       event.form.childFieldsLinkedToColumnName[event.targetColumnName].forEach((field: FormField, fieldIndex: number): void => {
 
-        let childFormSectionIdx: number = 0;
+        let childFormSectionIndex: number = 0;
         for (let i = 0; i < field.form.sections.length; i++) {
-          let innerFieldIdx: number = field.form.sections[i].fields.findIndex(
+          let innerFieldIndex: number = field.form.sections[i].fields.findIndex(
             (formField: FormField): boolean => {
 
               return (formField.id === field.id);
             }
           );
 
-          if (innerFieldIdx > -1) {
-            childFormSectionIdx = i;
+          if (innerFieldIndex > -1) {
+            childFormSectionIndex = i;
 
             break;
           }
         }
 
-        field.form.updateFieldValue(childFormSectionIdx, fieldIndex, event.newValue);
+        field.form.updateFieldValue(
+          childFormSectionIndex,
+          fieldIndex,
+          event.newValue,
+          null,
+          true
+        );
 
         this.afterChildFormEdit(
-          field.form.rowId ?? -1,
+          field.form?.rowId ?? -1,
           field.form
         );
       });
@@ -712,6 +718,7 @@ export class CinchyDynamicFormsComponent implements OnInit {
 
                   formData.updateRootProperty(
                     {
+                      ignoreChange: true,
                       propertyName: "hasChanged",
                       propertyValue: false
                     }

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -154,8 +154,6 @@ export class CinchyDynamicFormsComponent implements OnInit {
         else {
           this._queuedRecordSelection = record;
         }
-
-        this._updateFilteredTableUrl();
       }
     );
   }
@@ -696,16 +694,16 @@ export class CinchyDynamicFormsComponent implements OnInit {
                   if (!this.form?.rowId) {
                     // Technically this will also be done by the setRecordSelected handlers, but by doing it manually now we can use this immediately and won't
                     // need to wait for it to propagate
-                    formData.updateRootProperty(
+                    this.form.updateRootProperty(
                       {
                         propertyName: "rowId",
                         propertyValue: response.queryResult._jsonResult.data[0][0]
                       }
                     );
 
-                    this._updateFilteredTableUrl();
-
                     this._loadLookupRecords("", this.form.rowId);
+
+                    this._updateFilteredTableUrl(this.form.rowId);
 
                     if (this.form.isClone) {
                       this.form = this.form.clone(null, true);
@@ -715,6 +713,7 @@ export class CinchyDynamicFormsComponent implements OnInit {
                   }
 
                   await this._saveMethodLogic(response, childData);
+
                   this._updateFileAndSaveFileNames(insertQuery.attachedFilesInfo);
 
                   this._notificationService.displaySuccessMessage("Data Saved Successfully");
@@ -786,6 +785,10 @@ export class CinchyDynamicFormsComponent implements OnInit {
     else {
       this._appStateService.deleteRowIdInQueryParams();
     }
+
+    // Using record.rowId instead of this.form?.rowId because the network calls inside the loadForm function cause
+    // the logic of this function to continue asynchronously despite the await
+    this._updateFilteredTableUrl(record.rowId);
   }
 
 
@@ -919,10 +922,10 @@ export class CinchyDynamicFormsComponent implements OnInit {
   /**
    * Adds the current row information to the querystring of the table URL
    */
-  private _updateFilteredTableUrl(): void {
+  private _updateFilteredTableUrl(rowId: number): void {
 
-    this.filteredTableUrl = this.form?.rowId ?
-      `${this.formMetadata.tableUrl}?viewId=0&fil[Cinchy%20Id].Op=Equals&fil[Cinchy%20Id].Val=${this.form.rowId}` :
+    this.filteredTableUrl = rowId ?
+      `${this.formMetadata.tableUrl}?viewId=0&fil[Cinchy%20Id].Op=Equals&fil[Cinchy%20Id].Val=${rowId}` :
       "";
   }
 }

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -143,16 +143,8 @@ export class CinchyDynamicFormsComponent implements OnInit {
 
   ngOnInit(): void {
 
-    // DEBUG
-    // console.log("calling _loadLookupRecords from ngOnInit");
-
-    // this._loadLookupRecords("", this.form?.rowId);
-
     this._appStateService.onRecordSelected$.subscribe(
       (record: { rowId: number | null, doNotReloadForm: boolean }): void => {
-
-        // DEBUG
-        console.log("onRecordSelected$", record, this.lookupRecordsListPopulated, this.lookupRecords);
 
         if (this.lookupRecordsListPopulated) {
           this._handleRecordSelection(record);
@@ -351,9 +343,6 @@ export class CinchyDynamicFormsComponent implements OnInit {
     if (resolvedFilter && this.formMetadata.lookupFilter) {
       resolvedFilter += ` AND ${this.formMetadata.lookupFilter}`;
     }
-
-    // DEBUG
-    console.log("calling _loadLookupRecords from handleOnFilter");
 
     this._loadLookupRecords(resolvedFilter ?? this.formMetadata.lookupFilter);
   }
@@ -712,9 +701,6 @@ export class CinchyDynamicFormsComponent implements OnInit {
                       }
                     );
 
-                    // DEBUG
-                    console.log("calling _loadLookupRecords from saveForm");
-
                     this._loadLookupRecords("", this.form.rowId);
 
                     this._updateFilteredTableUrl(this.form.rowId);
@@ -821,10 +807,6 @@ export class CinchyDynamicFormsComponent implements OnInit {
     ).subscribe(
       {
         next: async (response: Array<ILookupRecord>): Promise<void> => {
-
-          // DEBUG
-          console.log("_loadLookupRecords", response);
-          console.log(this._queuedRecordSelection, rowIdToSelect, this.form?.rowId);
 
           this.lookupRecords = this.checkNoRecord(response);
 

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -148,8 +148,6 @@ export class CinchyDynamicFormsComponent implements OnInit {
 
         if (this.lookupRecordsListPopulated) {
           this._handleRecordSelection(record);
-
-          this._queuedRecordSelection = null;
         }
         else {
           this._queuedRecordSelection = record;
@@ -789,6 +787,8 @@ export class CinchyDynamicFormsComponent implements OnInit {
     // Using record.rowId instead of this.form?.rowId because the network calls inside the loadForm function cause
     // the logic of this function to continue asynchronously despite the await
     this._updateFilteredTableUrl(record.rowId);
+
+    this._queuedRecordSelection = null;
   }
 
 

--- a/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
+++ b/src/app/dynamic-forms/cinchy-dynamic-forms.component.ts
@@ -106,7 +106,7 @@ export class CinchyDynamicFormsComponent implements OnInit {
    */
   get canCreateNewRecord(): boolean {
 
-    return coerceBooleanProperty(this.canInsert && this._appStateService.rowId);
+    return coerceBooleanProperty(this.canInsert && this.form?.rowId);
   }
 
 
@@ -702,6 +702,8 @@ export class CinchyDynamicFormsComponent implements OnInit {
                       }
                     );
 
+                    this._updateFilteredTableUrl();
+
                     this._loadLookupRecords("", this.form.rowId);
 
                     if (this.form.isClone) {
@@ -775,6 +777,13 @@ export class CinchyDynamicFormsComponent implements OnInit {
 
     if (!record?.doNotReloadForm) {
       await this.loadForm(record.rowId);
+    }
+
+    if (this.currentRow?.id) {
+      this._appStateService.updateRowIdInQueryParams(this.currentRow.id);
+    }
+    else {
+      this._appStateService.deleteRowIdInQueryParams();
     }
   }
 
@@ -911,8 +920,8 @@ export class CinchyDynamicFormsComponent implements OnInit {
    */
   private _updateFilteredTableUrl(): void {
 
-    this.filteredTableUrl = this._appStateService.rowId ?
-      `${this.formMetadata.tableUrl}?viewId=0&fil[Cinchy%20Id].Op=Equals&fil[Cinchy%20Id].Val=${this._appStateService.rowId}` :
+    this.filteredTableUrl = this.form?.rowId ?
+      `${this.formMetadata.tableUrl}?viewId=0&fil[Cinchy%20Id].Op=Equals&fil[Cinchy%20Id].Val=${this.form.rowId}` :
       "";
   }
 }

--- a/src/app/dynamic-forms/fields-wrapper/fields-wrapper.component.html
+++ b/src/app/dynamic-forms/fields-wrapper/fields-wrapper.component.html
@@ -28,8 +28,7 @@
     <div class="form-field" *ngIf="!field.hide">
       <cinchy-checkbox *ngIf="(field.cinchyColumn.dataType === 'Yes/No')"
                         [targetTableName]="field.cinchyColumn.tableName"
-                        [field]="field"
-                        [form]="field.form"
+                        [form]="form"
                         [fieldIndex]="fieldIndex"
                         [sectionIndex]="sectionIndex"
                         (onChange)="handleOnChange($event)">
@@ -37,8 +36,7 @@
 
       <cinchy-link *ngIf="(field.cinchyColumn.dataType === 'Link' && field.cinchyColumn.canView && !field.cinchyColumn.isMultiple)"
                     [targetTableName]="field.cinchyColumn.tableName"
-                    [field]="field"
-                    [form]="field.form"
+                    [form]="form"
                     [fieldIndex]="fieldIndex"
                     [sectionIndex]="sectionIndex"
                     [fieldsWithErrors]="fieldsWithErrors"
@@ -49,8 +47,7 @@
 
       <cinchy-link-multichoice *ngIf="(field.cinchyColumn.dataType === 'Link' && field.cinchyColumn.canView && field.cinchyColumn.isMultiple)"
                                 [targetTableName]="field.cinchyColumn.tableName"
-                                [field]="field"
-                                [form]="field.form"
+                                [form]="form"
                                 [fieldIndex]="fieldIndex"
                                 [sectionIndex]="sectionIndex"
                                 [fieldsWithErrors]="fieldsWithErrors"
@@ -60,8 +57,7 @@
       <cinchy-textarea *ngIf="useTextarea(field)"
                         (onChange)="handleOnChange($event)"
                         [targetTableName]="field.cinchyColumn.tableName"
-                        [field]="field"
-                        [form]="field.form"
+                        [form]="form"
                         [fieldIndex]="fieldIndex"
                         [sectionIndex]="sectionIndex"
                         [isInChildForm]="isChild"
@@ -70,8 +66,7 @@
 
       <cinchy-textbox *ngIf="usePlaintext(field)"
                       [targetTableName]="field.cinchyColumn.tableName"
-                      [field]="field"
-                      [form]="field.form"
+                      [form]="form"
                       [fieldIndex]="fieldIndex"
                       [sectionIndex]="sectionIndex"
                       [fieldsWithErrors]="fieldsWithErrors"
@@ -81,8 +76,7 @@
 
       <cinchy-rich-text *ngIf="useRichText(field)"
                         [targetTableName]="field.cinchyColumn.tableName"
-                        [field]="field"
-                        [form]="field.form"
+                        [form]="form"
                         [fieldIndex]="fieldIndex"
                         [sectionIndex]="sectionIndex"
                         [fieldsWithErrors]="fieldsWithErrors"
@@ -92,8 +86,7 @@
 
       <cinchy-datetime *ngIf="(field.cinchyColumn.dataType === 'Date and Time')"
                         [targetTableName]="field.cinchyColumn.tableName"
-                        [field]="field"
-                        [form]="field.form"
+                        [form]="form"
                         [fieldIndex]="fieldIndex"
                         [sectionIndex]="sectionIndex"
                         [fieldsWithErrors]="fieldsWithErrors"
@@ -102,8 +95,7 @@
 
       <cinchy-attach-file *ngIf="(field.cinchyColumn.dataType === 'Binary')"
                           [targetTableName]="field.cinchyColumn.tableName"
-                          [field]="field"
-                          [form]="field.form"
+                          [form]="form"
                           [fieldIndex]="fieldIndex"
                           [sectionIndex]="sectionIndex"
                           [fieldsWithErrors]="fieldsWithErrors"
@@ -112,8 +104,7 @@
 
       <cinchy-choice *ngIf="field.cinchyColumn.dataType === 'Choice' && !field.cinchyColumn.isMultiple"
                       [targetTableName]="field.cinchyColumn.tableName"
-                      [field]="field"
-                      [form]="field.form"
+                      [form]="form"
                       [fieldIndex]="fieldIndex"
                       [sectionIndex]="sectionIndex"
                       [fieldsWithErrors]="fieldsWithErrors"
@@ -122,8 +113,7 @@
 
       <cinchy-multi-choice *ngIf="field.cinchyColumn.dataType === 'Choice' && field.cinchyColumn.isMultiple"
                             [targetTableName]="field.cinchyColumn.tableName"
-                            [field]="field"
-                            [form]="field.form"
+                            [form]="form"
                             [fieldIndex]="fieldIndex"
                             [sectionIndex]="sectionIndex"
                             [fieldsWithErrors]="fieldsWithErrors"
@@ -132,8 +122,7 @@
 
       <cinchy-number *ngIf="(field.cinchyColumn.dataType === 'Number')"
                       [targetTableName]="field.cinchyColumn.tableName"
-                      [field]="field"
-                      [form]="field.form"
+                      [form]="form"
                       [fieldIndex]="fieldIndex"
                       [sectionIndex]="sectionIndex"
                       [fieldsWithErrors]="fieldsWithErrors"
@@ -141,8 +130,7 @@
       </cinchy-number>
 
       <cinchy-childform-table *ngIf="field.childForm && !field.childForm.flatten"
-                              [field]="field"
-                              [form]="field.form"
+                              [form]="form"
                               [fieldIndex]="fieldIndex"
                               [sectionIndex]="sectionIndex"
                               (childRowDeleted)="childRowDeleted.emit($event)"

--- a/src/app/dynamic-forms/fields-wrapper/fields-wrapper.component.ts
+++ b/src/app/dynamic-forms/fields-wrapper/fields-wrapper.component.ts
@@ -75,7 +75,7 @@ export class FieldsWrapperComponent {
 
   onPanelExpanded(section: FormSection): void {
 
-    this._appStateService.currentSection$.next(section.label);
+    this._appStateService.sectionExpanded$.next(section.label);
   }
 
 

--- a/src/app/dynamic-forms/fields/attach-file/attach-file.component.ts
+++ b/src/app/dynamic-forms/fields/attach-file/attach-file.component.ts
@@ -19,7 +19,6 @@ import { faFile } from "@fortawesome/free-regular-svg-icons";
 })
 export class AttachFileComponent implements OnInit {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() sectionIndex: number;
   @Input() form: Form;
@@ -43,6 +42,12 @@ export class AttachFileComponent implements OnInit {
   showError: boolean;
 
   faFile = faFile;
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
+  }
 
 
   ngOnInit(): void {

--- a/src/app/dynamic-forms/fields/checkbox/checkbox.component.ts
+++ b/src/app/dynamic-forms/fields/checkbox/checkbox.component.ts
@@ -27,7 +27,6 @@ import { faCheckSquare } from "@fortawesome/free-regular-svg-icons";
 })
 export class CheckboxComponent implements OnChanges, OnInit {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() isDisabled: boolean;
@@ -55,6 +54,12 @@ export class CheckboxComponent implements OnChanges, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
+++ b/src/app/dynamic-forms/fields/child-form-table/child-form-table.component.ts
@@ -47,9 +47,10 @@ import { NotificationService } from "../../../services/notification.service";
 })
 export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
+
   @Input() form: Form;
+
   @Input() sectionIndex: number;
 
   @Output() childFormOpened = new EventEmitter<{
@@ -57,10 +58,12 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
     presetValues?: { [key: string]: any },
     title: string
   }>();
+
   @Output() childRowDeleted = new EventEmitter<{
     childForm: Form,
     rowId: number
   }>();
+
 
   fieldSet: Array<FormField> = new Array<FormField>();
   fieldKeys: Array<string> = new Array<string>();
@@ -91,6 +94,12 @@ export class ChildFormTableComponent implements OnChanges, OnInit, OnDestroy {
   get childForm(): Form {
 
     return this.form.sections[this.sectionIndex]?.fields[this.fieldIndex]?.childForm;
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/choice/choice.component.ts
+++ b/src/app/dynamic-forms/fields/choice/choice.component.ts
@@ -27,7 +27,6 @@ import { faListUl } from "@fortawesome/free-solid-svg-icons";
 })
 export class ChoiceComponent implements OnChanges, OnInit {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() isDisabled: boolean;
@@ -56,6 +55,12 @@ export class ChoiceComponent implements OnChanges, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/datetime/datetime.component.ts
+++ b/src/app/dynamic-forms/fields/datetime/datetime.component.ts
@@ -21,7 +21,6 @@ import * as moment from "moment";
 })
 export class DatetimeComponent implements OnChanges, OnInit {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() isDisabled: boolean;
@@ -51,6 +50,12 @@ export class DatetimeComponent implements OnChanges, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -56,7 +56,6 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
   @ViewChild("multiSelect", {static: true}) multiSelect: MatSelect;
   @ViewChild("t") public tooltip: NgbTooltip;
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() isInChildForm: boolean;
@@ -107,6 +106,12 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/link/link.component.ts
+++ b/src/app/dynamic-forms/fields/link/link.component.ts
@@ -66,7 +66,6 @@ export class LinkComponent implements OnChanges, OnInit {
   @ViewChild("fileInput") fileInput: ElementRef;
   @ViewChild("t") public tooltip: NgbTooltip;
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() formFieldMetadataResult: any;
@@ -138,6 +137,12 @@ export class LinkComponent implements OnChanges, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 
@@ -400,7 +405,7 @@ export class LinkComponent implements OnChanges, OnInit {
         this.filteredOptions = this._filter(this.autocompleteText);
 
         if (fromLinkedField) {
-          this._setValue();
+          this._setValue(true);
         }
       }
 

--- a/src/app/dynamic-forms/fields/link/link.component.ts
+++ b/src/app/dynamic-forms/fields/link/link.component.ts
@@ -582,13 +582,7 @@ export class LinkComponent implements OnChanges, OnInit {
     this.form.updateFieldValue(
       this.sectionIndex,
       this.fieldIndex,
-      this.form.rowId,
-      [
-        {
-          propertyName: "hasChanged",
-          propertyValue: true
-        }
-      ]
+      this.form.rowId
     );
 
     this.isDisabled = true;

--- a/src/app/dynamic-forms/fields/multichoice/multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/multichoice/multichoice.component.ts
@@ -27,7 +27,6 @@ import { faListUl } from "@fortawesome/free-solid-svg-icons";
 })
 export class MultichoiceComponent implements OnChanges {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() isDisabled: boolean;
@@ -57,6 +56,12 @@ export class MultichoiceComponent implements OnChanges {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/number/number.component.ts
+++ b/src/app/dynamic-forms/fields/number/number.component.ts
@@ -32,7 +32,6 @@ import { Form } from "../../models/cinchy-form.model";
 })
 export class NumberComponent implements OnChanges, OnInit {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() isDisabled: boolean;
@@ -70,6 +69,12 @@ export class NumberComponent implements OnChanges, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/rich-text/rich-text.component.ts
+++ b/src/app/dynamic-forms/fields/rich-text/rich-text.component.ts
@@ -79,8 +79,6 @@ import { FormField } from "../../models/cinchy-form-field.model";
 })
 export class RichTextComponent implements AfterViewInit, OnDestroy {
 
-  @Input() field: FormField;
-
   @Input() fieldIndex: number;
 
   @Input() form: Form;
@@ -185,6 +183,12 @@ export class RichTextComponent implements AfterViewInit, OnDestroy {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/textarea/textarea.component.ts
+++ b/src/app/dynamic-forms/fields/textarea/textarea.component.ts
@@ -34,7 +34,6 @@ export class TextareaComponent implements AfterViewInit, OnChanges, OnInit {
 
   @ViewChild("editor") editor;
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() targetTableName: string;
@@ -72,6 +71,12 @@ export class TextareaComponent implements AfterViewInit, OnChanges, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/fields/textbox/textbox.component.ts
+++ b/src/app/dynamic-forms/fields/textbox/textbox.component.ts
@@ -30,7 +30,6 @@ import { coerceBooleanProperty } from "@angular/cdk/coercion";
 })
 export class TextboxComponent implements OnChanges, OnInit {
 
-  @Input() field: FormField;
   @Input() fieldIndex: number;
   @Input() form: Form;
   @Input() isDisabled: boolean;
@@ -68,6 +67,12 @@ export class TextboxComponent implements OnChanges, OnInit {
   get canEdit(): boolean {
 
     return (!this.isDisabled && this.field.cinchyColumn.canEdit && !this.field.cinchyColumn.isViewOnly);
+  }
+
+
+  get field(): FormField {
+
+    return this.form?.sections[this.sectionIndex]?.fields[this.fieldIndex];
   }
 
 

--- a/src/app/dynamic-forms/interface/additional-property.ts
+++ b/src/app/dynamic-forms/interface/additional-property.ts
@@ -8,6 +8,12 @@ export interface IAdditionalProperty {
   cinchyColumn?: boolean;
 
   /**
+   * Indicates that the hasChanged value should not be flagged as part of this update, which is useful in cases where
+   * data that is meaningful to the application but not meaningful to the form is added
+   */
+  ignoreChange?: boolean;
+
+  /**
    * The name of the property to be updated
    */
   propertyName: string;

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -1136,25 +1136,34 @@ export class Form {
    * Updates the value of the given field and marks it as touched. If any additional properties are provided, those properties will be updated on
    * the same field after the value has been updated.
    */
-  updateFieldValue(sectionIndex: number, fieldIndex: number, newValue: any, additionalPropertiesToUpdate?: Array<IAdditionalProperty>): void {
+  updateFieldValue(
+    sectionIndex: number,
+    fieldIndex: number,
+    newValue: any,
+    additionalPropertiesToUpdate?: Array<IAdditionalProperty>,
+    ignoreChange = false
+  ): void {
 
     if (this._sections?.length > sectionIndex && this._sections[sectionIndex].fields?.length > fieldIndex) {
-      // Since we don't store the field's original value, we will mark it as changed if the current value is different from the
-      // value immediately prior, or if the field has already been marked as changed
-      const valueChanged: boolean = this._valuesAreDifferent(newValue, this._sections[sectionIndex].fields[fieldIndex].value);
+      if (!ignoreChange) {
+        // Since we don't store the field's original value, we will mark it as changed if the current value is different from the
+        // value immediately prior, or if the field has already been marked as changed
+        const valueChanged: boolean = this._valuesAreDifferent(newValue, this._sections[sectionIndex].fields[fieldIndex].value);
 
-      this.hasChanged = this.hasChanged || valueChanged;
+        this.hasChanged = this.hasChanged || valueChanged;
 
-      if (this.parentForm && this.hasChanged) {
-        this.parentForm.updateRootProperty(
-          {
-            propertyName: "hasChanged",
-            propertyValue: true
-          }
-        );
+        if (this.parentForm && this.hasChanged) {
+          this.parentForm.updateRootProperty(
+            {
+              propertyName: "hasChanged",
+              propertyValue: true
+            }
+          );
+        }
+
+        this._sections[sectionIndex].fields[fieldIndex].cinchyColumn.hasChanged = this._sections[sectionIndex].fields[fieldIndex].cinchyColumn.hasChanged || valueChanged;
       }
 
-      this._sections[sectionIndex].fields[fieldIndex].cinchyColumn.hasChanged = this._sections[sectionIndex].fields[fieldIndex].cinchyColumn.hasChanged || valueChanged;
       this._sections[sectionIndex].fields[fieldIndex].value = newValue;
 
       additionalPropertiesToUpdate?.forEach((property: IAdditionalProperty) => {
@@ -1170,7 +1179,9 @@ export class Form {
    */
   updateRootProperty(property: IAdditionalProperty): void {
 
-    this.hasChanged = this.hasChanged || this._valuesAreDifferent(property.propertyValue, this[property.propertyName]);
+    if (!property.ignoreChange) {
+      this.hasChanged = this.hasChanged || this._valuesAreDifferent(property.propertyValue, this[property.propertyName]);
+    }
 
     this[property.propertyName] = property.propertyValue;
   }
@@ -1181,7 +1192,9 @@ export class Form {
    */
   updateSectionProperty(sectionIndex: number, property: IAdditionalProperty): void {
 
-    this.hasChanged = this.hasChanged || this._valuesAreDifferent(property.propertyValue, this.sections[sectionIndex][property.propertyName]);
+    if (!property.ignoreChange) {
+      this.hasChanged = this.hasChanged || this._valuesAreDifferent(property.propertyValue, this.sections[sectionIndex][property.propertyName]);
+    }
 
     if (this._sections?.length > sectionIndex) {
       this._sections[sectionIndex][property.propertyName] = property.propertyValue;

--- a/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
+++ b/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
@@ -334,7 +334,12 @@ export class FormHelperService {
         }
       }
 
-      form.fieldsByColumnName = parentFieldsByColumn;
+      form.updateRootProperty(
+        {
+          propertyName: "fieldsByColumnName",
+          propertyValue: parentFieldsByColumn
+        }
+      );
 
       // TODO: this should be a forEach
       for (let i: number = 0; i < allChildForms.length; i++) {
@@ -362,7 +367,12 @@ export class FormHelperService {
         }
       }
 
-      form.childFieldsLinkedToColumnName = parentChildLinkedColumns;
+      form.updateRootProperty(
+        {
+          propertyName: "childFieldsLinkedToColumnName",
+          propertyValue: parentChildLinkedColumns
+        }
+      );
     }
   }
 

--- a/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
+++ b/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
@@ -118,9 +118,26 @@ export class FormHelperService {
       childFormSort
     );
 
-    result.tableMetadata = JSON.parse(formMetadata.tableJson);
-    result.parentForm = parentForm
-    result.rowId = rowId;
+    result.updateRootProperty(
+      {
+        propertyName: "tableMetadata",
+        propertyValue: JSON.parse(formMetadata.tableJson)
+      }
+    );
+
+    result.updateRootProperty(
+      {
+        propertyName: "parentForm",
+        propertyValue: parentForm
+      }
+    );
+
+    result.updateRootProperty(
+      {
+        propertyName: "rowId",
+        propertyValue: rowId
+      }
+    );
 
     return result;
   }

--- a/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
+++ b/src/app/dynamic-forms/service/form-helper/form-helper.service.ts
@@ -120,6 +120,7 @@ export class FormHelperService {
 
     result.updateRootProperty(
       {
+        ignoreChange: true,
         propertyName: "tableMetadata",
         propertyValue: JSON.parse(formMetadata.tableJson)
       }
@@ -127,6 +128,7 @@ export class FormHelperService {
 
     result.updateRootProperty(
       {
+        ignoreChange: true,
         propertyName: "parentForm",
         propertyValue: parentForm
       }
@@ -134,6 +136,7 @@ export class FormHelperService {
 
     result.updateRootProperty(
       {
+        ignoreChange: true,
         propertyName: "rowId",
         propertyValue: rowId
       }
@@ -353,6 +356,7 @@ export class FormHelperService {
 
       form.updateRootProperty(
         {
+          ignoreChange: true,
           propertyName: "fieldsByColumnName",
           propertyValue: parentFieldsByColumn
         }
@@ -386,6 +390,7 @@ export class FormHelperService {
 
       form.updateRootProperty(
         {
+          ignoreChange: true,
           propertyName: "childFieldsLinkedToColumnName",
           propertyValue: parentChildLinkedColumns
         }

--- a/src/app/pages/form-wrapper/form-wrapper.component.html
+++ b/src/app/pages/form-wrapper/form-wrapper.component.html
@@ -35,12 +35,10 @@
   </ng-template>
 
   <ng-template #mainContent>
-    <div class="form-container full-height-element" [ngStyle]="{ 'height': fullScreenHeight }" *ngIf="formSectionsMetadata && lookupRecords">
+    <div class="form-container full-height-element" [ngStyle]="{ 'height': fullScreenHeight }" *ngIf="formSectionsMetadata">
       <cinchy-dynamic-forms [formId]="formId"
                             [formMetadata]="formMetadata"
-                            [formSectionsMetadata]="formSectionsMetadata"
-                            [lookupRecords]="lookupRecords"
-                            (onLookupRecordFilter)="handleOnLookupRecordFilter($event)">
+                            [formSectionsMetadata]="formSectionsMetadata">
       </cinchy-dynamic-forms>
     </div>
   </ng-template>

--- a/src/app/pages/form-wrapper/form-wrapper.component.html
+++ b/src/app/pages/form-wrapper/form-wrapper.component.html
@@ -35,7 +35,7 @@
   </ng-template>
 
   <ng-template #mainContent>
-    <div class="form-container full-height-element" [ngStyle]="{ 'height': fullScreenHeight }" *ngIf="formSectionsMetadata">
+    <div class="form-container full-height-element" [ngStyle]="{ 'height': fullScreenHeight }">
       <cinchy-dynamic-forms [formId]="formId"
                             [formMetadata]="formMetadata"
                             [formSectionsMetadata]="formSectionsMetadata">

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -121,10 +121,12 @@ export class AppStateService {
 
     this._rowId = rowId;
 
-    this.onRecordSelected$.next({
-      rowId: rowId,
-      doNotReloadForm: doNotReloadForm
-    });
+    this.onRecordSelected$.next(
+      {
+        rowId: rowId,
+        doNotReloadForm: doNotReloadForm
+      }
+    );
 
     if (rowId === null) {
       this.deleteRowIdInQueryParams();

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -108,6 +108,9 @@ export class AppStateService {
    */
   setRecordSelected(rowId: number | null, doNotReloadForm: boolean = false): void {
 
+    // DEBUG
+    console.log("setRecordSelected", rowId, doNotReloadForm);
+
     this.onRecordSelected$.next(
       {
         rowId: rowId,

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -108,9 +108,6 @@ export class AppStateService {
    */
   setRecordSelected(rowId: number | null, doNotReloadForm: boolean = false): void {
 
-    // DEBUG
-    console.log("setRecordSelected", rowId, doNotReloadForm);
-
     this.onRecordSelected$.next(
       {
         rowId: rowId,

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -1,6 +1,5 @@
 import {
   BehaviorSubject,
-  Observable,
   Subject
 } from "rxjs";
 
@@ -23,8 +22,8 @@ export class AppStateService {
 
   addNewEntityDialogClosed$ = new Subject<INewEntityDialogResponse>();
   childRecordUpdated$ = new Subject<void>();
-  currentSection$ = new BehaviorSubject<string>(null);
-  latestRenderedSections$ = new BehaviorSubject<IFormSectionMetadata[]>(null);
+  sectionExpanded$ = new BehaviorSubject<string>(null);
+  latestRenderedSections$ = new BehaviorSubject<Array<IFormSectionMetadata>>(null);
 
   parentFormSavedFromChild$ = new Subject<{
     childForm: Form,
@@ -45,7 +44,7 @@ export class AppStateService {
 
 
   /**
-   * The ID of the primary form, as provided by the query params when the application is bootstrapped. If there is a secondary form present,
+   * The ID of the root form, as provided by the query params when the application is bootstrapped. If there is a secondary form present,
    * either from the add new option dialog or because a child form is present, that ID is tracked independently
    */
   get formId(): string {
@@ -56,19 +55,8 @@ export class AppStateService {
 
 
   /**
-   * The ID of the currently-selected record on the root form in the main view container. The concept of a selected record is meaningless in the context of
-   * creating a new record, and child forms will track their own selected record ID independently, if present.
-   */
-  get rowId(): number {
-
-    return this._rowId;
-  }
-  private _rowId: number;
-
-
-  /**
-   * Removes the rowId parameter from the querystring of the application and, if the app is embedded in an iframe, the wrapping view. If the app is not
-   * embedded, then posting the message will have no effect.
+   * Removes the rowId parameter from the querystring of the application and, if the app is embedded in an iframe, the
+   * wrapping view. If the app is not embedded, then posting the message will have no effect.
    */
   deleteRowIdInQueryParams() {
 
@@ -101,7 +89,8 @@ export class AppStateService {
 
 
   /**
-   * Stores the ID of the root form at the application level. Child forms load their IDs locally, and should not affect hte application state
+   * Stores the ID of the root form at the application level. Child forms load their IDs locally, and should not affect
+   * the application state
    */
   setRootFormId(id: string): void {
 
@@ -112,14 +101,12 @@ export class AppStateService {
 
 
   /**
-   * Stores the selected record in the service and updates the application state to match it
+   * Notifies the application that a new record has been selected
    *
    * @param rowId The Cinchy ID of the selected record. If null, the selected record has been cleared
    * @param doNotReloadForm Indicates that a refresh is not required
    */
   setRecordSelected(rowId: number | null, doNotReloadForm: boolean = false): void {
-
-    this._rowId = rowId;
 
     this.onRecordSelected$.next(
       {
@@ -127,17 +114,16 @@ export class AppStateService {
         doNotReloadForm: doNotReloadForm
       }
     );
-
-    if (rowId === null) {
-      this.deleteRowIdInQueryParams();
-    }
-    else {
-      this.updateRowIdInQueryParams(rowId);
-    }
   }
 
 
-  updateRowIdInQueryParams(rowId: number) {
+  /**
+   * Updates the queryParams of both the application and (if present) its wrapper with the given rowId. If the rowId
+   * argument is not present in the URL already, it will be added.
+   *
+   * @param rowId The rowId to be inserted
+   */
+  updateRowIdInQueryParams(rowId: number): void {
 
     const messageJSON = {
       updateCinchyURLParams:
@@ -160,7 +146,7 @@ export class AppStateService {
       const [key, value] = paramString.split("=");
 
       // Because the key here will be an empty string in the case the queryParams are empty or malformed,
-      // we explicitly need to check that it is truthy. Optional chaining would yield a false position
+      // we explicitly need to check that it is truthy. Optional chaining would yield a false positive
       if (key && key.toLowerCase() !== "rowid") {
         return `${key}=${value}`;
       }

--- a/src/app/shared/search-dropdown/search-dropdown.component.html
+++ b/src/app/shared/search-dropdown/search-dropdown.component.html
@@ -1,7 +1,7 @@
 <mat-form-field class="search-dropdown" appearance="outline">
   <mat-label>Search Records</mat-label>
   <mat-select [(ngModel)]="selectedRecordId"
-              (ngModelChange)="onSelect($event)"
+              (ngModelChange)="onSelect()"
               panelClass="fix-width-470">
     <mat-option>
       <ngx-mat-select-search [formControl]="filterCtrl"

--- a/src/app/shared/search-dropdown/search-dropdown.component.ts
+++ b/src/app/shared/search-dropdown/search-dropdown.component.ts
@@ -108,6 +108,13 @@ export class SearchDropdownComponent implements AfterViewInit, OnChanges, OnDest
   ngOnChanges(changes: SimpleChanges): void {
 
     if (changes.items) {
+      if (this.items?.length && this.items[0].id !== -1 && this.selectedRecordId) {
+        this.selectedRecord = this.items.find((item: ILookupRecord) => {
+
+          return (item.id === this.selectedRecordId);
+        });
+      }
+
       this.setDisplayItems();
     }
   }
@@ -122,7 +129,7 @@ export class SearchDropdownComponent implements AfterViewInit, OnChanges, OnDest
   /**
    * Runs when the user selects an item from the dropdown
    */
-  onSelect(event: number) {
+  onSelect(): void {
 
     this.selectedRecord = this.displayItems.find((value: ILookupRecord) => {
 
@@ -138,7 +145,7 @@ export class SearchDropdownComponent implements AfterViewInit, OnChanges, OnDest
   /**
    * Sets up the set of options to be displayed
    */
-  setDisplayItems() {
+  setDisplayItems(): void {
 
     if (this.noRecordsAfterFilter) {
       this.displayItems = this.items.slice();
@@ -146,7 +153,7 @@ export class SearchDropdownComponent implements AfterViewInit, OnChanges, OnDest
     else {
       let displayItems = this.selectedRecord ? [Object.assign({}, this.selectedRecord)] : [];
 
-      if (this.items) {
+      if (this.items?.length) {
         const resolvedItems = this.items.slice(0, CinchyQueryService.LOOKUP_RECORD_LABEL_COUNT);
 
         resolvedItems.forEach((value: ILookupRecord) => {

--- a/src/app/shared/search-dropdown/search-dropdown.component.ts
+++ b/src/app/shared/search-dropdown/search-dropdown.component.ts
@@ -15,8 +15,7 @@ import {
   OnChanges,
   OnDestroy,
   Output,
-  SimpleChanges,
-  ViewChild
+  SimpleChanges
 } from "@angular/core";
 import { FormControl } from "@angular/forms";
 
@@ -89,9 +88,6 @@ export class SearchDropdownComponent implements AfterViewInit, OnChanges, OnDest
   }
 
 
-  constructor() {}
-
-
   ngAfterViewInit() {
 
     // listen for search field value changes
@@ -112,7 +108,6 @@ export class SearchDropdownComponent implements AfterViewInit, OnChanges, OnDest
   ngOnChanges(changes: SimpleChanges): void {
 
     if (changes.items) {
-
       this.setDisplayItems();
     }
   }


### PR DESCRIPTION
Author or reviewer, don’t forget the [guidelines](https://cinchy.visualstudio.com/Cinchy/_wiki/wikis/Cinchy.wiki/448/Pull-Requests).

---

# Overview

While testing for the 5.11 release, several bugs were discovered:

1) the first load of the form for a new record would not allow the form to be saved because it could not recognize when there were changes.

2) a regression where the lookup records could not be pre-populated and would not correctly select a newly-created record after a save

3) unchanged forms were incorrectly being marked as changed when the application loaded and after a save

# Details

1) The issue appeared to boil down to the fact that the form reference was being lost at some point over the course of the lifecycle (i.e. event.form in the handleFieldsEvent function, which fires when a field is changed, was not equal to the Form model stored in the CinchyDynamicFormsComponent). This meant that the hasChanged flag being set on the event form was not bubbling up to the view, and thus the validation determined that no save was needed.

The solution came in two parts:

a) Removal of the rowId field on the CinchyDynamicForms component so that the Form at that level would always be the source of truth

b) Ensuring that any Form reference passed to another component always used exactly the same one that was passed to it from the higher-level component.

---

2) This issue stemmed from improper handling of the record selection observable coupled with some timing issues related to when the call to select a record was made. The solution was to fully encapsulate the population of the lookup record to the CinchyDynamicFormsComponent (removing the initial call to the server from the FormsWrapperComponent) and removing the disconnect between the concept of a display set for the lookup records which differed from the actual data. This meant that the new record could be selected immediately without switching contexts or sending events between components, but also that the responsibility for making that selection had to be tied to the process of populating the lookup records themselves so that the timing of retrieving and selecting the record wouldn't be in competition.

---

3) Since the Form model is now being used immutably, any changes have to go through the public functions of that model, and logic had to be added to ensure that changes which add information that is important for the application but not the data/view (e.g. reference metadata) could be done without marking the Form as dirty since it is not being interacted with by the user.

# Risk

Either low or moderate. On the one hand, the CinchyDynamicFormsComponent, which is the scaffold on which the entire architecture of this app's functionality was built, was essentially gutted to accommodate for this change, and that will always result in some level of risk. However, the tightened scope and removal of complexity will make the component easier to troubleshoot and maintain moving forward, and also mitigates the risk of errors arising from the desynchronization of any models that get passed between components (both because those models are less likely to change in a narrower scope and because this is happening less overall).

Thorough testing was done to ensure that the Form model was used in a way that assumed it was entirely immutable outside of the internal functions which are called to change any value on the Form or its associated FormSection and FormField children (though enforcing true immutability would be a lot more work), and the values for hasChanged and rowId were monitored on that model through various workflows and state changes. At this time, the author believes the system to be stable in this regard.

# Testing

Several standard workflows should be tested to determine that the behaviour remains as expected, and that the form can be saved when it is valid regardless of the external state:

- Loading a fresh form without a prepopulated rowId (AKA in create mode), making changes, and saving the form
  - expected: save should complete without error
- Loading a fresh form with a prepopulatd rowId (AKA in edit mode), making changes, and saving the form
  - expected: save should complete without error
- Loading a fresh form without a prepopulated rowId, attempting to save without making changes
  - expected: warning that no changes were made
- Loading a fresh form with a prepopulatd rowId, attempting to save without making changes
  - expected: warning that no changes were made
- Loading a form in any state, selecting a pre-existing record, making changes, and saving the form
  - expected: save should complete without error
- Loading a form with a prepopulatd rowId, selecting "create a new record", making changes, and saving the form
  - expected: save should complete without error

Any further iterations on the above would further justify the stability of these changes

# Docs

## Release notes

N/A (regression)

## Change log

N/A
