### PR TITLE
CIN-09434: Ignore deleted display columns when rendering a form

### DIFF
--- a/src/app/constants/regex-column-name-in-error.constant.ts
+++ b/src/app/constants/regex-column-name-in-error.constant.ts
@@ -1,0 +1,9 @@
+﻿/**
+ * Used to extract the name of an affected column from an error message in the case that a column listed in a CQL query
+ * is not available.
+ *
+ * On MSSQL: `The column [COLUMN_NAME] could not be found` -> [`[COLUMN_NAME]`]
+ *
+ * On Aurora: `The column "COLUMN_NAME" could not be found` -> [`"COLUMN_NAME"`]
+ */
+export const REGEX_COLUMN_NAME_IN_ERROR = /(?:\[([^\[\]]+)])|(?:"([a-zA-Z0-9\s]+)")/g;

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.html
@@ -91,11 +91,15 @@
 
       <mat-select class="form-control" multiple #multiSelect
                   *ngIf="!isLoading && !downloadLink"
-                  [(ngModel)]="selectedValues" [ngModelOptions]="{standalone: true}"
+                  [(ngModel)]="selectedValues" [ngModelOptions]="{ standalone: true }"
                   [compareWith]="compareFn"
                   [disabled]="!canEdit"
                   (selectionChange)="valueChanged()"
                   disableOptionCentering>
+        <mat-select-trigger>
+          {{ displayFn() }}
+        </mat-select-trigger>
+
         <ng-container *ngIf="dropdownSetOptions">
           <mat-option>
             <ngx-mat-select-search class="multi-search"
@@ -115,7 +119,7 @@
             <mat-option class="all-options" *cdkVirtualFor="let dropdownOption of filteredListMulti | async"
                         [value]="dropdownOption"
                         [title]="dropdownOption.label">
-              {{dropdownOption.displayOnlyLabel ?? dropdownOption.label ?? ""}}
+              {{ dropdownOption.displayOnlyLabel ?? dropdownOption.label ?? "" }}
             </mat-option>
 
             <!--

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -53,7 +53,7 @@ import * as R from "ramda";
 export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
 
   @ViewChild("fileInput") fileInput: ElementRef;
-  @ViewChild("multiSelect", {static: true}) multiSelect: MatSelect;
+  @ViewChild("multiSelect", { static: true }) multiSelect: MatSelect;
   @ViewChild("t") public tooltip: NgbTooltip;
 
   @Input() fieldIndex: number;
@@ -268,6 +268,19 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
   compareFn(a: DropdownOption, b: DropdownOption): boolean {
 
     return (a?.id === b?.id);
+  }
+
+
+  /**
+   * Ensures that any display columns used to identify options in this set are ignored when showing the value of
+   * any options which are currently selected
+   */
+  displayFn(): string {
+
+    return this.selectedValues?.map((value: DropdownOption) => {
+
+      return value?.label;
+    })?.join(". ");
   }
 
 

--- a/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
+++ b/src/app/dynamic-forms/fields/link-multichoice/link-multichoice.component.ts
@@ -196,7 +196,6 @@ export class LinkMultichoiceComponent implements OnChanges, OnDestroy, OnInit {
       if (this.field.cinchyColumn.linkTargetColumnId) {
         dropdownDataset = await this._dropdownDatasetService.getDropdownDataset(
           this.field.cinchyColumn.linkTargetColumnId,
-          this.field.label,
           currentFieldJson,
           this.field.cinchyColumn.dropdownFilter,
           this.form.rowId

--- a/src/app/dynamic-forms/fields/link/link.component.ts
+++ b/src/app/dynamic-forms/fields/link/link.component.ts
@@ -385,7 +385,6 @@ export class LinkComponent implements OnChanges, OnInit {
       if (!isNullOrUndefined(this.field.cinchyColumn.linkTargetColumnId)) {
         dropdownDataset = await this._dropdownDatasetService.getDropdownDataset(
           this.field.cinchyColumn.linkTargetColumnId,
-          this.field.label,
           currentFieldJson,
           this.field.cinchyColumn.dropdownFilter,
           this.form.rowId,

--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -5,6 +5,9 @@ import { CinchyService } from "@cinchy-co/angular-sdk";
 import { DropdownDataset } from "./cinchy-dropdown-dataset";
 import { DropdownOption } from "./cinchy-dropdown-options";
 
+import { ErrorService } from "../../../services/error.service";
+import { NotificationService } from "../../../services/notification.service";
+
 
 @Injectable({
   providedIn: "root"
@@ -15,7 +18,9 @@ export class DropdownDatasetService {
 
 
   constructor(
-    private _cinchyService: CinchyService
+    private _cinchyService: CinchyService,
+    private _errorService: ErrorService,
+    private _notificationService: NotificationService
   ) {}
 
 
@@ -122,6 +127,9 @@ export class DropdownDatasetService {
           if (row[`display-${displayIndex}`]) {
             label += `, ${row[`display-${displayIndex}`]}`;
           }
+          else {
+            break;
+          }
         }
         while (++displayIndex);
 
@@ -146,7 +154,7 @@ export class DropdownDatasetService {
         const displayColumnsFoundInErrorResponse = displayColumnsToIgnore?.slice() ?? new Array<string>();
 
         do {
-          // WIll match a column name in the form of `[COLUMN_NAME]`, resulting in an array with [`[COLUMN_NAME]`]
+          // Will match a column name in the form of `[COLUMN_NAME]`, resulting in an array with [`[COLUMN_NAME]`]
           columnMatch = errorMessage.substring(startingIndex).match(/\[([^\[\]]+)]/g);
 
           if (columnMatch?.length) {
@@ -161,6 +169,11 @@ export class DropdownDatasetService {
         // errorMessage.matchAll(/\[([^\[\]]+)]/g); -> [[`[COLUMN_NAME]`, `COLUMN_NAME`]], ... ]
 
         return await this.getDropdownDataset(linkTargetColumnId, currentFieldJson, dropdownFilter, rowId, needUpdate, displayColumnsFoundInErrorResponse);
+      }
+      else {
+        this._notificationService.displayErrorMessage(
+          `Could not retrieve linked options for [${metadataQueryResult[0]["Domain"]}].[${metadataQueryResult[0]["Table"]}]. ${this._errorService.getErrorMessage(error)}`
+        );
       }
     }
   }

--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -140,7 +140,8 @@ export class DropdownDatasetService {
     }
     catch (error: any) {
       // Target the specific response of "Column [COLUMN_NAME] could not be found", indicating that a display
-      // column is not available or has been deleted. If that error occurs, compile a set of
+      // column is not available or has been deleted. If that error occurs, compile a set of affected column names and
+      // remove those from the set of requested display columns before resending hte response
       if (error.cinchyException?.data.status === 400 && error.cinchyException?.data.details.includes("could not be found")) {
         const errorMessage = error.cinchyException.data.details as string;
 

--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -114,8 +114,16 @@ export class DropdownDatasetService {
     try {
       (await this._cinchyService.executeCsql(dataSetQuery, params).toPromise()).queryResult.toObjectArray().forEach(function (row) {
 
-        // TODO For now only showing one display column (display-0)
-        const label = row["display-0"] ? `${row["Label"]}, ${row["display-0"]}` : row["Label"];
+        let label = row["Label"];
+
+        let displayIndex = 0;
+
+        do {
+          if (row[`display-${displayIndex}`]) {
+            label += `, ${row[`display-${displayIndex}`]}`;
+          }
+        }
+        while (++displayIndex);
 
         optionArray.push(new DropdownOption(row["Id"].toString(), row["Label"]?.toString(), label));
       });

--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -193,13 +193,15 @@ export class DropdownDatasetService {
     let displayColumnQueryItems: Array<string> = new Array<string>();
 
     if (currentFieldJson.SearchDisplayColumns?.length) {
+      let displayIndex = 0;
+
       currentFieldJson.SearchDisplayColumns.forEach(
         (column: { name: string }, index: number) => {
 
           const key: string = column.name ? column.name.split(".")[0] : "";
 
           if (key && !displayColumnsToIgnore.includes(key)) {
-            displayColumnQueryItems.push(`[${key}] as 'display-${index}'`)
+            displayColumnQueryItems.push(`[${key}] as 'display-${displayIndex++}'`)
           }
         }
       );

--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -141,7 +141,7 @@ export class DropdownDatasetService {
     catch (error: any) {
       // Target the specific response of "Column [COLUMN_NAME] could not be found", indicating that a display
       // column is not available or has been deleted. If that error occurs, compile a set of affected column names and
-      // remove those from the set of requested display columns before resending hte response
+      // remove those from the set of requested display columns before resending the response
       if (error.cinchyException?.data.status === 400 && error.cinchyException?.data.details.includes("could not be found")) {
         const errorMessage = error.cinchyException.data.details as string;
 

--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -142,18 +142,23 @@ export class DropdownDatasetService {
       if (error.cinchyException?.data.status === 400 && error.cinchyException?.data.details.includes("could not be found")) {
         const errorMessage = error.cinchyException.data.details as string;
 
-        let columnMatch: Array<string> | null = errorMessage.substring(0).match(/\[([^\[\]]+)]/g);
+        let columnMatch: Array<string> | null = errorMessage.substring(0).match(/"([a-zA-Z0-9\s]+)"/g);
         let startingIndex = 0;
 
         // If this process needs to repeat for multiple display columns (and those display columns aren't all included
         // in the error), then use what was already provided and build on it
         const displayColumnsFoundInErrorResponse = displayColumnsToIgnore?.slice() ?? new Array<string>();
 
-        // Will match a column name in the form of `[COLUMN_NAME]`, resulting in an array with [`[COLUMN_NAME]`]
+        // Will match a column name in the form of `"COLUMN_NAME"`, resulting in an array with [`"COLUMN_NAME"`]
         while (columnMatch?.length) {
           startingIndex = errorMessage.indexOf(columnMatch[0]) + columnMatch[0].length;
 
-          displayColumnsFoundInErrorResponse.push(columnMatch[0].replace("[", "").replace("]", ""));
+          displayColumnsFoundInErrorResponse.push(
+            columnMatch[0]
+              // Needs to be done twice because we can't yet use .replaceAll
+              .replace("\"", "")
+              .replace("\"", "")
+          );
 
           columnMatch = errorMessage.substring(startingIndex).match(/\[([^\[\]]+)]/g);
         }

--- a/src/app/services/cinchy-query.service.ts
+++ b/src/app/services/cinchy-query.service.ts
@@ -186,6 +186,7 @@ export class CinchyQueryService {
       FROM [${domain}].[${table}]
       WHERE [Deleted] IS NULL
         AND [${subCol}] IS NOT NULL
+        AND trim([${subCol}]) != ''
         ${lookupFilter ? `AND ${lookupFilter}` : ''}
       ORDER BY [${subCol}];`;
 


### PR DESCRIPTION
# Description

Author or reviewer, don’t forget the [guidelines](https://cinchy.visualstudio.com/Cinchy/_wiki/wikis/Cinchy.wiki/448/Pull-Requests).

-----

# Overview

In cases where a link column has been configured with a set of display columns (which is done at the column level) and one
 or more of those columns is unavailable, the app was throwing an uncaught exception and the field would break.

# Details


It was decided that the correct behaviour was to squash the error and fail gracefully, rendering without the failing display column(s). This was accomplished by parsing the error statement returned by the initial attempt (since we can't know ahead of time what is broken), parsing out the relevant column(s), and then reconstructing the original query without the failing column(s) included.

# Risk

Minimal. Since the flow of logic is exactly the same, the only concern would be something breaking in the thoroughly-tested retry logic

# Testing

To reproduce:

- create a link column on Table A targeting Table B, adding at least one display column from Table B
- delete one or more of the display columns you have set from Table B
- add the link column on Table A to a form as a link or multichoice link field
- prior to this fix, the error should appear in the console and the link field will not populate
- after this fix, the link field should populate as expected, without displaying any values from the deleted display column. Note that the failed request still happens and can be inspected, and the console will reflect this error accordingly

# Docs

## Release notes

If you have deleted one or more display columns associated with a link or multichoice link field on a form, that field will no longer fail to load.

## Change log

N/A