### PR TITLE
CIN-09125: Filter empty label from lookup record

### DIFF
--- a/src/app/services/cinchy-query.service.ts
+++ b/src/app/services/cinchy-query.service.ts
@@ -186,6 +186,7 @@ export class CinchyQueryService {
       FROM [${domain}].[${table}]
       WHERE [Deleted] IS NULL
         AND [${subCol}] IS NOT NULL
+        AND trim([${subCol}]) != ''
         ${lookupFilter ? `AND ${lookupFilter}` : ''}
       ORDER BY [${subCol}];`;
 


### PR DESCRIPTION
Minor fix for the issue that was causing empty labels to be shown in the record selector (the filter was checking for NULL, but it didn't account for empty strings generated by calculated values).