### PR TITLE
CIN-10083: Fix to update url and dropdown selection on search record change

### DIFF
--- a/src/app/shared/search-dropdown/search-dropdown.component.ts
+++ b/src/app/shared/search-dropdown/search-dropdown.component.ts
@@ -98,8 +98,10 @@ export class SearchDropdownComponent implements AfterViewInit, OnChanges, OnDest
         debounceTime(500),
       )
       .subscribe(() => {
-
-        this.onFilter.emit(this.filterCtrl.value);
+        // Explicitly checking for an empty string here because the filter value can be set to null and we want that to go through
+        if (this.filterCtrl.value !== "") {
+          this.onFilter.emit(this.filterCtrl.value);
+        }
       })
     );
   }


### PR DESCRIPTION
Author or reviewer, don’t forget the [guidelines](https://cinchy.visualstudio.com/Cinchy/_wiki/wikis/Cinchy.wiki/448/Pull-Requests).

---

# Overview

- Selecting a new record does not update url and selection to newly selected record

# Details

- This issue only occurs on the first time of selecting a different record, any selections after that works fine.
- On the first time of selecting a record the formCtrl subscription emits an event even though user did not type anything to filter down. Adding a empty value check to ensure filter only emits on user input. 
- This check explicitly allows `null` value to go through because on init we still need to initialize the filter form

# Risk

- Low

# Testing

- Test that selecting new record updates the url and selection

# Docs

## Release notes

- Selecting new records now updates the url and selection properly