### PR TITLE
CIN-09434: Fix executeCQL loop 

### DIFF
--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -87,7 +87,7 @@ export class DropdownDatasetService {
 
       if (linkFilterExpression) {
         whereCondition += ` AND ${linkFilterExpression}`;
-      } 
+      }
 
       if (dropdownFilter && !displayColumnsToIgnore?.some(column => dropdownFilter.includes(column))) {
         whereCondition += ` AND ${dropdownFilter}`;

--- a/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
+++ b/src/app/dynamic-forms/service/cinchy-dropdown-dataset/cinchy-dropdown-dataset.service.ts
@@ -87,9 +87,9 @@ export class DropdownDatasetService {
 
       if (linkFilterExpression) {
         whereCondition += ` AND ${linkFilterExpression}`;
-      }
+      } 
 
-      if (dropdownFilter) {
+      if (dropdownFilter && !displayColumnsToIgnore?.some(column => dropdownFilter.includes(column))) {
         whereCondition += ` AND ${dropdownFilter}`;
       }
 


### PR DESCRIPTION
When the column in "Dropdown Column Filter" does not exist, executeCQL errors out and goes into a retry loop. In a previous implementation of this ticket, it only ignored bad column names in the "SELECT" clause, but we also have ignore the "WHERE" clause so the query can go through.