### PR TITLE
Fix untouched Date/Time fields being nulled when saving a child form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-forms",
-  "version": "5.19.3",
+  "version": "5.19.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-forms",
-  "version": "5.19.3",
+  "version": "5.19.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 3000 --ssl",

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -1237,7 +1237,7 @@ export class Form {
     // Values the user has not modified retain the raw ISO representation from the database
     // rather than the column's display format
     if (!valueAsMoment.isValid()) {
-      valueAsMoment = moment(value, moment.ISO_8601);
+      valueAsMoment = moment(value, moment.ISO_8601, true);
     }
 
     if (!valueAsMoment.isValid()) {

--- a/src/app/dynamic-forms/models/cinchy-form.model.ts
+++ b/src/app/dynamic-forms/models/cinchy-form.model.ts
@@ -1234,6 +1234,12 @@ export class Form {
 
     let valueAsMoment: moment.Moment = moment(value, originalFormat);
 
+    // Values the user has not modified retain the raw ISO representation from the database
+    // rather than the column's display format
+    if (!valueAsMoment.isValid()) {
+      valueAsMoment = moment(value, moment.ISO_8601);
+    }
+
     if (!valueAsMoment.isValid()) {
       return null;
     }

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -80,7 +80,7 @@ export class AppStateService {
       if (key && key.toLowerCase() !== "rowid") {
         return `${key}=${value}`;
       }
-    }).join("");
+    }).filter(Boolean).join("&");
 
     const baseUrl = window.location.href.substr(0, window.location.href.indexOf("?"));
 
@@ -150,7 +150,7 @@ export class AppStateService {
       if (key && key.toLowerCase() !== "rowid") {
         return `${key}=${value}`;
       }
-    }).join("");
+    }).filter(Boolean).join("&");
 
     if (queryParams?.length) {
       const baseUrl = window.location.href.substr(0, window.location.href.indexOf("?"));

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -73,12 +73,12 @@ export class AppStateService {
     // Modifies the app's URL
     const queryParams = window.location.search?.substr(1).split("&").map((paramString: string) => {
 
-      const [key, value] = paramString.split("=");
+      const [key, ...valueParts] = paramString.split("=");
 
       // Because the key here will be an empty string in the case the queryParams are empty or malformed,
       // we explicitly need to check that it is truthy. Optional chaining would yield a false position
       if (key && key.toLowerCase() !== "rowid") {
-        return `${key}=${value}`;
+        return `${key}=${valueParts.join("=")}`;
       }
     }).filter(Boolean).join("&");
 
@@ -143,12 +143,12 @@ export class AppStateService {
 
     const queryParams = window.location.search?.substr(1).split("&").map((paramString: string) => {
 
-      const [key, value] = paramString.split("=");
+      const [key, ...valueParts] = paramString.split("=");
 
       // Because the key here will be an empty string in the case the queryParams are empty or malformed,
       // we explicitly need to check that it is truthy. Optional chaining would yield a false positive
       if (key && key.toLowerCase() !== "rowid") {
-        return `${key}=${value}`;
+        return `${key}=${valueParts.join("=")}`;
       }
     }).filter(Boolean).join("&");
 

--- a/src/healthcheck
+++ b/src/healthcheck
@@ -1,6 +1,6 @@
 {
     "component":"Meta-Forms",
-    "version": "5.19.3",
+    "version": "5.19.4",
     "buildIdentifier": "",
     "githubURL": "https://github.com/cinchy-co/meta-forms-app-experience"
 }


### PR DESCRIPTION
## Summary

Editing one Date/Time field in a child form dialog and saving nulled out the other Date/Time fields in the same record (reported by TD on Forms 5.18; silent data loss on save).

**Root cause:** opening the child form edit dialog marks every populated field as changed, so untouched date columns are included in the save UPDATE. Their values are still the raw ISO strings returned by the database, which fail to parse against the column's display format in `_getISOStringFromDateString()` and were serialized as empty — writing NULL over the stored value. Introduced in v5.10.0 (#176/#177), affects all releases since.

**Fix:** when the display-format parse fails, retry with a strict `moment.ISO_8601` parse before returning null. The fallback only activates in the case that currently destroys data; all working paths (picker-edited values, empty values, no display format, `Date` objects) behave identically to before.

Also includes a small fix to query-string reassembly in `app-state.service.ts`: params were joined without `&` separators when the URL is rewritten on record selection, producing malformed URLs on refresh/bookmark.

## Verification

- Reproduced the reported data loss on a QA form (edit one date in child dialog → save parent → sibling date nulled in DB, confirmed via captured `ExecuteCQL` payload matching TD's evidence exactly).
- After the fix, the identical flow preserves the untouched date; confirmed persisted after hard reload.
- Ran the serializer logic against all input shapes (raw ISO + format, display value + format, no format, Date object, empty, garbage) — only the previously-data-destroying case changes behavior.

Note: untouched fields are still included in the UPDATE (they now round-trip their own value). Removing those spurious writes requires changing the child-form dialog's change tracking, which has broader blast radius and should be a separate, QA'd change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)